### PR TITLE
Fixes for oss-fuzz:556439 and oss-fuzz:556443

### DIFF
--- a/encoder/svc/isvce_api.c
+++ b/encoder/svc/isvce_api.c
@@ -4474,8 +4474,8 @@ static WORD32 isvce_get_buf_info(void *pv_codec_handle, void *pv_api_ip, void *p
     for(i = 0; i < (WORD32) ps_op->s_ive_op.u4_out_comp_cnt; i++)
     {
         ps_op->s_ive_op.au4_min_out_buf_size[i] =
-            MAX(((wd * ht * 3) >> 1) * ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers,
-                MIN_STREAM_SIZE);
+            MAX(((wd * ht * 3) >> 1), MIN_STREAM_SIZE) *
+            ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
     }
 
     ps_op->u4_rec_comp_cnt = MIN_RAW_BUFS_420_COMP;

--- a/encoder/svc/isvce_encode.c
+++ b/encoder/svc/isvce_encode.c
@@ -198,7 +198,8 @@ WORD32 isvce_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
     /* Check for output memory allocation size */
     {
         UWORD32 u4_min_bufsize =
-            MIN_STREAM_SIZE * ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
+            MAX(MIN_STREAM_SIZE, (ps_codec->s_cfg.u4_wd * ps_codec->s_cfg.u4_ht * 3) / 2) *
+            ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
         UWORD32 u4_bufsize_per_layer = ps_video_encode_ip->s_ive_ip.s_out_buf.u4_bufsize /
                                        ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
 


### PR DESCRIPTION
Fixed incorrect outbuf size assignment in 'isvce_get_buf_info'

BUG=oss-fuzz:55639
BUG=oss-fuzz:55643
Test: svc_enc_fuzzer