### PR TITLE
svcenc: fixed riscv4 soong build errors

### DIFF
--- a/encoder/riscv/svc/isvce_function_selector.c
+++ b/encoder/riscv/svc/isvce_function_selector.c
@@ -37,7 +37,9 @@
 *******************************************************************************
 */
 
+#include "ih264_typedefs.h"
 #include "iv2.h"
+#include "isvce_platform_macros.h"
 #include "isvce_structs.h"
 
 /**

--- a/encoder/riscv/svc/isvce_platform_macros.h
+++ b/encoder/riscv/svc/isvce_platform_macros.h
@@ -37,6 +37,7 @@
 #ifndef _ISVCE_PLATFORM_MACROS_H_
 #define _ISVCE_PLATFORM_MACROS_H_
 
+#include "isvce_structs.h"
 /*****************************************************************************/
 /* Extern Function Declarations                                              */
 /*****************************************************************************/

--- a/encoder/svc/isvce_downscaler.c
+++ b/encoder/svc/isvce_downscaler.c
@@ -443,7 +443,7 @@ void isvce_downscaler_function_selector(downscaler_state_t *ps_scaler_state, IV_
 
             break;
         }
-#elif !defined(DISABLE_NEON)
+#elif defined(ARM) && !defined(DISABLE_NEON)
         case ARCH_ARM_A9Q:
         case ARCH_ARM_A9A:
         case ARCH_ARM_A9:

--- a/encoder/svc/isvce_ibl_eval.c
+++ b/encoder/svc/isvce_ibl_eval.c
@@ -916,7 +916,7 @@ void isvce_intra_sampling_function_selector(intra_sampling_ctxt_t *ps_ctxt,
 
                 break;
             }
-#elif !defined(DISABLE_NEON)
+#elif defined(ARM) && !defined(DISABLE_NEON)
             case ARCH_ARM_A9Q:
             case ARCH_ARM_A9A:
             case ARCH_ARM_A9:

--- a/encoder/svc/isvce_rc_utils.c
+++ b/encoder/svc/isvce_rc_utils.c
@@ -223,7 +223,7 @@ static void isvce_get_gpp_function_selector(svc_rc_utils_state_t *ps_rc_utils_st
 
             break;
         }
-#elif !defined(DISABLE_NEON)
+#elif defined(ARM) && !defined(DISABLE_NEON)
         case ARCH_ARM_A9Q:
         case ARCH_ARM_A9A:
         case ARCH_ARM_A9:

--- a/encoder/svc/isvce_residual_pred.c
+++ b/encoder/svc/isvce_residual_pred.c
@@ -794,7 +794,7 @@ void isvce_svc_residual_sampling_function_selector(res_pred_state_t *ps_res_pred
 
                 break;
             }
-#elif !defined(DISABLE_NEON)
+#elif defined(ARM) && !defined(DISABLE_NEON)
             case ARCH_ARM_A9Q:
             case ARCH_ARM_A9A:
             case ARCH_ARM_A9:
@@ -836,7 +836,7 @@ void isvce_svc_residual_sampling_function_selector(res_pred_state_t *ps_res_pred
 
             break;
     }
-#elif !defined(DISABLE_NEON)
+#elif defined(ARM) && !defined(DISABLE_NEON)
         case ARCH_ARM_A9Q:
         case ARCH_ARM_A9A:
         case ARCH_ARM_A9:


### PR DESCRIPTION
riscv4 soong builds were failing due to incorrect usage of 'ARM' macro. This was fixed.