### PR TITLE
svcenc: increased minimum outbuf size

### DIFF
--- a/encoder/svc/isvce_api.c
+++ b/encoder/svc/isvce_api.c
@@ -4473,8 +4473,7 @@ static WORD32 isvce_get_buf_info(void *pv_codec_handle, void *pv_api_ip, void *p
     for(i = 0; i < (WORD32) ps_op->s_ive_op.u4_out_comp_cnt; i++)
     {
         ps_op->s_ive_op.au4_min_out_buf_size[i] =
-            MAX(((wd * ht * 3) >> 1), MIN_STREAM_SIZE) *
-            ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
+            isvce_get_min_outbuf_size(wd, ht, ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers);
     }
 
     ps_op->u4_rec_comp_cnt = MIN_RAW_BUFS_420_COMP;

--- a/encoder/svc/isvce_encode.c
+++ b/encoder/svc/isvce_encode.c
@@ -198,8 +198,8 @@ WORD32 isvce_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
     /* Check for output memory allocation size */
     {
         UWORD32 u4_min_bufsize =
-            MAX(MIN_STREAM_SIZE, (ps_codec->s_cfg.u4_wd * ps_codec->s_cfg.u4_ht * 3) / 2) *
-            ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
+            isvce_get_min_outbuf_size(ps_codec->s_cfg.u4_wd, ps_codec->s_cfg.u4_ht,
+                                      ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers);
         UWORD32 u4_bufsize_per_layer = ps_video_encode_ip->s_ive_ip.s_out_buf.u4_bufsize /
                                        ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers;
 

--- a/encoder/svc/isvce_utils.c
+++ b/encoder/svc/isvce_utils.c
@@ -4540,3 +4540,8 @@ void isvce_join_threads(isvce_codec_t *ps_codec)
 
     ps_codec->i4_proc_thread_cnt = 0;
 }
+
+UWORD32 isvce_get_min_outbuf_size(UWORD32 u4_wd, UWORD32 u4_ht, UWORD8 u1_num_spatial_layers)
+{
+    return MAX((u4_wd * u4_ht * 3), MIN_STREAM_SIZE) * u1_num_spatial_layers;
+}

--- a/encoder/svc/isvce_utils.h
+++ b/encoder/svc/isvce_utils.h
@@ -231,4 +231,7 @@ extern WORD32 isvce_input_queue_update(isvce_codec_t *ps_codec, ive_video_encode
 
 extern void isvce_join_threads(isvce_codec_t *ps_codec);
 
+extern UWORD32 isvce_get_min_outbuf_size(UWORD32 u4_wd, UWORD32 u4_ht,
+                                         UWORD8 u1_num_spatial_layers);
+
 #endif


### PR DESCRIPTION
For certain configurations of the fuzzer input, the minimum output buffer size is insufficient.
The minimum value has been doubled in this commit.

BUG=oss-fuzz:55797
Test: svc_enc_fuzzer