### PR TITLE
svcenc: fixed a bug in low bitrate encodes

### DIFF
--- a/encoder/svc/isvce_api.c
+++ b/encoder/svc/isvce_api.c
@@ -3550,7 +3550,7 @@ static WORD32 isvce_init_mem_rec(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *
 
                 /* ps_mb_qp_ctxt */
                 ps_codec->as_process[i].s_entropy.ps_mb_qp_ctxt = (mb_qp_ctxt_t *) (pu1_buf + size);
-                size = ALIGN128(sizeof(ps_codec->as_process[i].s_entropy.ps_mb_qp_ctxt[0]));
+                size += ALIGN128(sizeof(ps_codec->as_process[i].s_entropy.ps_mb_qp_ctxt[0]));
 
                 offset = size;
 

--- a/encoder/svc/isvce_process.c
+++ b/encoder/svc/isvce_process.c
@@ -426,7 +426,7 @@ WORD32 isvce_update_rc_post_enc(isvce_codec_t *ps_codec, WORD32 ctxt_sel, WORD32
 
                 svc_au_data_t *ps_svc_au_data = ps_svc_ilp_data->ps_svc_au_data;
 
-                WORD32 i4_num_mbs = (ps_proc->i4_ht_mbs * ps_proc->i4_wd_mbs) / (MB_SIZE * MB_SIZE);
+                WORD32 i4_num_mbs = ps_proc->i4_ht_mbs * ps_proc->i4_wd_mbs;
 
                 ps_layer_data = &ps_svc_au_data->ps_svc_layer_data[ps_entropy->u1_spatial_layer_id];
 


### PR DESCRIPTION
Certain ILP buffers are reset when encoded bitrate exceeds configured bitrate. The size used for one of them was incorrect.