### PR TITLE
Format Android.bp files

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -41,7 +41,7 @@ cc_library_headers {
         "common",
         "common/svc",
         "encoder",
-        "encoder/svc"
+        "encoder/svc",
     ],
     min_sdk_version: "29",
 }
@@ -52,7 +52,7 @@ cc_library_headers {
         "common",
         "common/svc",
         "decoder",
-        "decoder/svc"
+        "decoder/svc",
     ],
     min_sdk_version: "29",
 }
@@ -161,7 +161,7 @@ cc_defaults {
 }
 
 cc_defaults {
-    name: "libavc_mvc_svc_dec_defaults",
+    name: "libavc_dec_defaults",
     cflags: [
         "-fPIC",
         "-O3",
@@ -258,7 +258,7 @@ cc_defaults {
 
 cc_library_static {
     name: "libavcdec",
-    defaults: ["libavc_mvc_svc_dec_defaults"],
+    defaults: ["libavc_dec_defaults"],
 
     export_include_dirs: [
         "common",
@@ -440,7 +440,7 @@ cc_library_static {
 
 cc_library_static {
     name: "libmvcdec",
-    defaults: ["libavc_mvc_svc_dec_defaults"],
+    defaults: ["libavc_dec_defaults"],
     whole_static_libs: [
         "libavcdec",
     ],
@@ -817,7 +817,7 @@ cc_library_static {
 
 cc_library_static {
     name: "libsvcdec",
-    defaults: ["libavc_mvc_svc_dec_defaults"],
+    defaults: ["libavc_dec_defaults"],
     whole_static_libs: [
         "libavcdec",
     ],

--- a/test/Android.bp
+++ b/test/Android.bp
@@ -8,9 +8,9 @@ package {
 }
 
 cc_defaults {
-    name: "libavc_mvc_svc_app_defaults",
+    name: "avcdec_defaults",
     gtest: false,
-    host_supported:true,
+    host_supported: true,
     cflags: [
         "-DPROFILE_ENABLE",
         "-DARM",
@@ -28,9 +28,9 @@ cc_defaults {
 }
 
 cc_defaults {
-    name: "libavc_enc_app_defaults",
+    name: "avcenc_defaults",
     gtest: false,
-    host_supported:true,
+    host_supported: true,
     cflags: [
         "-DPROFILE_ENABLE",
         "-DARM",
@@ -41,16 +41,16 @@ cc_defaults {
         "-Wno-unused-variable",
     ],
     local_include_dirs: [
-        "encoder/",
+        "encoder",
     ],
     static_libs: ["libavcenc"],
 }
 
 cc_test {
     name: "avcdec",
-    defaults: ["libavc_mvc_svc_app_defaults"],
+    defaults: ["avcdec_defaults"],
     local_include_dirs: [
-        "decoder/",
+        "decoder",
     ],
     srcs: ["decoder/main.c"],
     static_libs: ["libavcdec"],
@@ -58,9 +58,9 @@ cc_test {
 
 cc_test {
     name: "mvcdec",
-    defaults: ["libavc_mvc_svc_app_defaults"],
+    defaults: ["avcdec_defaults"],
     local_include_dirs: [
-        "mvcdec/",
+        "mvcdec",
     ],
     srcs: ["mvcdec/main.c"],
     static_libs: [
@@ -70,7 +70,7 @@ cc_test {
 
 cc_test {
     name: "avcenc",
-    defaults: ["libavc_enc_app_defaults"],
+    defaults: ["avcenc_defaults"],
 
     srcs: [
         "encoder/main.c",
@@ -83,10 +83,10 @@ cc_test {
 
 cc_test {
     name: "svcenc",
-    defaults: ["libavc_enc_app_defaults"],
+    defaults: ["avcenc_defaults"],
 
     local_include_dirs: [
-        "svcenc/",
+        "svcenc",
     ],
 
     srcs: [
@@ -104,10 +104,10 @@ cc_test {
 
 cc_test {
     name: "svcdec",
-    defaults: ["libavc_mvc_svc_app_defaults"],
+    defaults: ["avcdec_defaults"],
 
     local_include_dirs: [
-        "svcdec/",
+        "svcdec",
     ],
 
     srcs: [


### PR DESCRIPTION
Minor changes in names of defaults in order get consistency between libraries and applications being built.

Test: builds