### PR TITLE
avc_enc_fuzzer: Add #include <tuple>

### DIFF
--- a/fuzzer/avc_enc_fuzzer.cpp
+++ b/fuzzer/avc_enc_fuzzer.cpp
@@ -20,6 +20,7 @@
 #include <malloc.h>
 #include <algorithm>
 #include <string.h>
+#include <tuple>
 #include <vector>
 
 #include "ih264_defs.h"


### PR DESCRIPTION
included <tuple> to fix errors seen when using some compilers