### PR TITLE
svcenc: RC bitrate overflows prevented

### DIFF
--- a/encoder/svc/isvce_encode.c
+++ b/encoder/svc/isvce_encode.c
@@ -246,6 +246,12 @@ WORD32 isvce_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
         isvce_codec_init(ps_codec);
     }
 
+    error_status =
+        isvce_svc_frame_params_validate(ps_codec->s_rate_control.apps_rate_control_api,
+                                        ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers);
+    SET_ERROR_ON_RETURN(error_status, IVE_UNSUPPORTEDPARAM,
+                        ps_video_encode_op->s_ive_op.u4_error_code, IV_FAIL);
+
     /* parse configuration params */
     for(i = 0; i < MAX_ACTIVE_CONFIG_PARAMS; i++)
     {

--- a/encoder/svc/isvce_rc_mem_interface.c
+++ b/encoder/svc/isvce_rc_mem_interface.c
@@ -244,9 +244,9 @@ WORD32 isvce_get_rate_control_mem_tab(void *pv_rate_control, iv_mem_rec_t *ps_me
         refptr1[RC_MEM_FRAME_TIME] = &ps_rate_control->pps_frame_time;
         refptr1[RC_MEM_TIME_STAMP] = &ps_rate_control->pps_time_stamp;
         refptr1[RC_MEM_FRAME_RATE] = &ps_rate_control->pps_pd_frm_rate;
-        refptr1[RC_MEM_API_L0] = &ps_rate_control->apps_rate_control_api[0];
-        refptr1[RC_MEM_API_L1] = &ps_rate_control->apps_rate_control_api[1];
-        refptr1[RC_MEM_API_L2] = &ps_rate_control->apps_rate_control_api[2];
+        refptr1[RC_MEM_API_L0] = (void **) &ps_rate_control->apps_rate_control_api[0];
+        refptr1[RC_MEM_API_L1] = (void **) &ps_rate_control->apps_rate_control_api[1];
+        refptr1[RC_MEM_API_L2] = (void **) &ps_rate_control->apps_rate_control_api[2];
     }
 
     /* Get the total number of memtabs used by Frame time Module */

--- a/encoder/svc/isvce_structs.h
+++ b/encoder/svc/isvce_structs.h
@@ -65,8 +65,23 @@
 #include "ih264e_cabac_structs.h"
 #include "ih264e_defs.h"
 #include "ime_structs.h"
+
+/* Dependencies of 'irc_picture_type.h' */
 #include "irc_cntrl_param.h"
 #include "irc_frame_info_collector.h"
+#include "irc_mem_req_and_acq.h"
+
+/* Dependencies of 'irc_rate_control_api_structs' */
+#include "irc_picture_type.h"
+#include "irc_rd_model.h"
+#include "irc_vbr_storage_vbv.h"
+#include "irc_est_sad.h"
+#include "irc_bit_allocation.h"
+#include "irc_mb_model_based.h"
+#include "irc_cbr_buffer_control.h"
+#include "irc_vbr_str_prms.h"
+#include "irc_common.h"
+#include "irc_rate_control_api_structs.h"
 
 #include "ih264e_structs.h"
 #include "isvce_cabac_structs.h"
@@ -76,9 +91,6 @@
 #include "isvce_nalu_stat_aggregator.h"
 #include "isvce_pred_structs.h"
 #include "isvce_rc_utils.h"
-
-#include "irc_cntrl_param.h"
-#include "irc_frame_info_collector.h"
 
 typedef struct svc_params_t
 {
@@ -723,7 +735,7 @@ typedef struct isvce_entropy_ctxt_t
  */
 typedef struct isvce_rate_control_ctxt_t
 {
-    void *apps_rate_control_api[MAX_NUM_SPATIAL_LAYERS];
+    rate_control_api_t *apps_rate_control_api[MAX_NUM_SPATIAL_LAYERS];
 
     void *pps_frame_time;
 

--- a/encoder/svc/isvce_utils.c
+++ b/encoder/svc/isvce_utils.c
@@ -518,6 +518,37 @@ WORD32 isvce_svc_inp_params_validate(isvce_init_ip_t *ps_ip, isvce_cfg_params_t 
 *******************************************************************************
 *
 * @brief
+*  Validates SVC frame-level input params
+*
+* @param[in] ps_cfg
+*  Cfg parameters
+*
+* @returns  error code in conformance with 'IH264E_ERROR_T'
+*
+*******************************************************************************
+*/
+WORD32 isvce_svc_frame_params_validate(
+    rate_control_api_t *aps_rate_control_api[MAX_NUM_SPATIAL_LAYERS], UWORD8 u1_num_spatial_layers)
+{
+    WORD32 i;
+
+    /* RC requires total bits in a second to fit int32_t */
+    for(i = 0; i < u1_num_spatial_layers; i++)
+    {
+        if((((UWORD64) irc_get_bits_per_frame(aps_rate_control_api[i])) *
+            irc_get_intra_frame_interval(aps_rate_control_api[i])) > ((UWORD64) INT32_MAX))
+        {
+            return IH264E_BITRATE_NOT_SUPPORTED;
+        }
+    }
+
+    return IV_SUCCESS;
+}
+
+/**
+*******************************************************************************
+*
+* @brief
 *  Used to get reference picture buffer size for a given level and
 *  and padding used
 *

--- a/encoder/svc/isvce_utils.h
+++ b/encoder/svc/isvce_utils.h
@@ -46,6 +46,21 @@
 
 #include "ih264_typedefs.h"
 #include "ih264e_bitstream.h"
+/* Dependencies of 'irc_picture_type.h' */
+#include "irc_cntrl_param.h"
+#include "irc_frame_info_collector.h"
+#include "irc_mem_req_and_acq.h"
+/* Dependencies of 'irc_rate_control_api_structs' */
+#include "irc_picture_type.h"
+#include "irc_rd_model.h"
+#include "irc_vbr_storage_vbv.h"
+#include "irc_est_sad.h"
+#include "irc_bit_allocation.h"
+#include "irc_mb_model_based.h"
+#include "irc_cbr_buffer_control.h"
+#include "irc_vbr_str_prms.h"
+#include "irc_common.h"
+#include "irc_rate_control_api_structs.h"
 #include "isvc_macros.h"
 #include "isvc_structs.h"
 #include "isvce_defs.h"
@@ -164,6 +179,9 @@ extern WORD32 isvce_svc_au_props_validate(svc_inp_params_t *ps_svc_inp_params, U
                                           UWORD32 u4_svc_comp_ht);
 
 extern WORD32 isvce_svc_inp_params_validate(isvce_init_ip_t *ps_ip, isvce_cfg_params_t *ps_cfg);
+
+extern WORD32 isvce_svc_frame_params_validate(
+    rate_control_api_t *aps_rate_control_api[MAX_NUM_SPATIAL_LAYERS], UWORD8 u1_num_spatial_layers);
 
 extern WORD32 isvce_get_total_svc_au_buf_size(svc_inp_params_t *ps_svc_inp_params,
                                               WORD32 i4_pic_size, WORD32 i4_level,


### PR DESCRIPTION
RC uses int32_t for storing multiple quantities related to bits in a given period.
'isvce_svc_frame_params_validate' has been added, which queries RC API for the relevant quantities and returns with and error if computations involving those quantities exceed INT32_MAX.

BUG = ossfuzz:274221347
BUG = ossfuzz:274265498
Test: svc_enc_fuzzer