### PR TITLE
svcenc: nullSan errors in ILPMv fixed

### DIFF
--- a/encoder/svc/isvce_process.c
+++ b/encoder/svc/isvce_process.c
@@ -2375,7 +2375,8 @@ WORD32 isvce_process(isvce_process_ctxt_t *ps_proc)
             ps_proc->ps_mb_info->u1_base_mode_flag = 0;
         }
 
-        isvce_mvp_idx_eval(ps_proc->ps_mb_info, ps_proc->ps_pred_mv, ps_proc->ps_ilp_mv->as_mv[0],
+        isvce_mvp_idx_eval(ps_proc->ps_mb_info, ps_proc->ps_pred_mv,
+                           ps_proc->ps_ilp_mv ? ps_proc->ps_ilp_mv->as_mv[0] : NULL,
                            ps_proc->s_me_ctxt.pu1_mv_bits);
 
         /* 8x8 Tx is not supported, and I8x8 is also unsupported */
@@ -2472,7 +2473,8 @@ WORD32 isvce_process(isvce_process_ctxt_t *ps_proc)
             ps_sub_pic_rc_variables->u4_cbp = ps_proc->u4_cbp;
             ps_sub_pic_rc_variables->aps_mvps[0] = ps_proc->ps_pred_mv;
 #if MAX_MVP_IDX == 1
-            ps_sub_pic_rc_variables->aps_mvps[1] = ps_proc->ps_ilp_mv->as_mv[0];
+            ps_sub_pic_rc_variables->aps_mvps[1] =
+                ps_proc->ps_ilp_mv ? ps_proc->ps_ilp_mv->as_mv[0] : NULL;
 #endif
             ps_sub_pic_rc_variables->apu1_nnzs[Y] = (UWORD8 *) ps_proc->au4_nnz;
             ps_sub_pic_rc_variables->apu1_nnzs[UV] = ps_proc->au1_chroma_nnz;


### PR DESCRIPTION
The ILP MV struct pointer will be set to NULL for I slices and for spatial layer ID 0. A NULL check ought to be used in all places that access this pointer. This was missing in 2 places and has been added.

Test: svc_enc_fuzzer