### PR TITLE
encoder: Initialize s_inp_buf and s_out_buf to zero in ih264e_encode

### DIFF
--- a/encoder/ih264e_encode.c
+++ b/encoder/ih264e_encode.c
@@ -215,8 +215,8 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
     ih264e_video_encode_op_t *ps_video_encode_op = pv_api_op;
 
     /* i/o structures */
-    inp_buf_t s_inp_buf;
-    out_buf_t s_out_buf;
+    inp_buf_t s_inp_buf = {};
+    out_buf_t s_out_buf = {};
 
     /* temp var */
     WORD32 ctxt_sel = 0, i, i4_rc_pre_enc_skip;


### PR DESCRIPTION
In some cases, s_inp_buf and s_out_buf on stack in ih264e_encode() can be accessed unininitialized. This is fixed by initializing these two structures.

Bug: oss-fuzz:57333
Bug: 274906999
Test: avc_enc_fuzzer