### PR TITLE
Revert "libavcenc: Correct default values in ih264e_defs.h"

### DIFF
--- a/encoder/ih264e_api.c
+++ b/encoder/ih264e_api.c
@@ -1295,8 +1295,8 @@ static IV_STATUS_T api_check_struct_sanity(iv_obj_t *ps_handle,
                         return IV_FAIL;
                     }
 
-                    if ((ps_ip->s_ive_ip.u4_src_frame_rate > DEFAULT_MAX_FRAMERATE)
-                                    || (ps_ip->s_ive_ip.u4_tgt_frame_rate > DEFAULT_MAX_FRAMERATE))
+                    if (((ps_ip->s_ive_ip.u4_src_frame_rate * 1000) > DEFAULT_MAX_FRAMERATE)
+                                    || ((ps_ip->s_ive_ip.u4_tgt_frame_rate * 1000) > DEFAULT_MAX_FRAMERATE))
                     {
                         ps_op->s_ive_op.u4_error_code |= 1
                                         << IVE_UNSUPPORTEDPARAM;
@@ -2848,7 +2848,7 @@ static WORD32 ih264e_set_default_params(cfg_params_t *ps_cfg)
     ps_cfg->e_recon_color_fmt = IV_YUV_420P;
     ps_cfg->u4_enc_speed_preset = IVE_FASTEST;
     ps_cfg->e_rc_mode = DEFAULT_RC;
-    ps_cfg->u4_max_framerate = DEFAULT_MAX_FRAMERATE * 1000;
+    ps_cfg->u4_max_framerate = DEFAULT_MAX_FRAMERATE;
     ps_cfg->u4_max_bitrate = DEFAULT_MAX_BITRATE;
     ps_cfg->u4_num_bframes = DEFAULT_MAX_NUM_BFRAMES;
     ps_cfg->e_content_type = IV_PROGRESSIVE;
@@ -2862,8 +2862,8 @@ static WORD32 ih264e_set_default_params(cfg_params_t *ps_cfg)
     ps_cfg->u4_disp_ht = MAX_HT;
     ps_cfg->u4_wd = MAX_WD;
     ps_cfg->u4_ht = MAX_HT;
-    ps_cfg->u4_src_frame_rate = DEFAULT_SRC_FRAME_RATE * 1000;
-    ps_cfg->u4_tgt_frame_rate = DEFAULT_TGT_FRAME_RATE * 1000;
+    ps_cfg->u4_src_frame_rate = DEFAULT_SRC_FRAME_RATE;
+    ps_cfg->u4_tgt_frame_rate = DEFAULT_TGT_FRAME_RATE;
     ps_cfg->u4_target_bitrate = DEFAULT_BITRATE;
     ps_cfg->e_frame_type = IV_NA_FRAME;
     ps_cfg->e_enc_mode = IVE_ENC_MODE_DEFAULT;
@@ -2905,9 +2905,9 @@ static WORD32 ih264e_set_default_params(cfg_params_t *ps_cfg)
     ps_cfg->e_cmd = IVE_CMD_CT_NA;
     ps_cfg->i4_wd_mbs = ps_cfg->u4_max_wd >> 4;
     ps_cfg->i4_ht_mbs = ps_cfg->u4_max_ht >> 4;
-    ps_cfg->u4_entropy_coding_mode = DEFAULT_ENTROPY_CODING_MODE;
+    ps_cfg->u4_entropy_coding_mode = CAVLC;
     ps_cfg->u4_weighted_prediction = 0;
-    ps_cfg->u4_constrained_intra_pred = DEFAULT_CONSTRAINED_INTRAPRED;
+    ps_cfg->u4_constrained_intra_pred = 0;
     ps_cfg->u4_pic_info_type = 0;
     ps_cfg->u4_mb_info_type = 0;
     ps_cfg->s_vui.u1_video_signal_type_present_flag = 0;
@@ -4177,7 +4177,7 @@ static WORD32 ih264e_init_mem_rec(iv_obj_t *ps_codec_obj,
     ps_cfg->u4_max_level = ps_ip->s_ive_ip.u4_max_level;
     ps_cfg->e_inp_color_fmt = ps_ip->s_ive_ip.e_inp_color_fmt;
     ps_cfg->e_recon_color_fmt = ps_ip->s_ive_ip.e_recon_color_fmt;
-    ps_cfg->u4_max_framerate = ps_ip->s_ive_ip.u4_max_framerate * 1000;
+    ps_cfg->u4_max_framerate = ps_ip->s_ive_ip.u4_max_framerate;
     ps_cfg->u4_max_bitrate = ps_ip->s_ive_ip.u4_max_bitrate;
     ps_cfg->u4_num_bframes = ps_ip->s_ive_ip.u4_num_bframes;
     ps_cfg->e_content_type = ps_ip->s_ive_ip.e_content_type;

--- a/encoder/ih264e_defs.h
+++ b/encoder/ih264e_defs.h
@@ -244,14 +244,14 @@
 #define DEFAULT_RECON_ENABLE            0
 #define DEFAULT_QUALITY_METRICS_ENABLE  0
 #define DEFAULT_RC                      IVE_RC_STORAGE
-#define DEFAULT_MAX_FRAMERATE           120
+#define DEFAULT_MAX_FRAMERATE           120000
 #define DEFAULT_MAX_BITRATE             240000000
 #define DEFAULT_MAX_NUM_BFRAMES         0
 #define DEFAULT_MAX_SRCH_RANGE_X        256
 #define DEFAULT_MAX_SRCH_RANGE_Y        256
 #define DEFAULT_SLICE_PARAM             256
-#define DEFAULT_SRC_FRAME_RATE          30
-#define DEFAULT_TGT_FRAME_RATE          30
+#define DEFAULT_SRC_FRAME_RATE          30000
+#define DEFAULT_TGT_FRAME_RATE          30000
 #define DEFAULT_BITRATE                 6000000
 #define DEFAULT_QP_MIN                  10
 #define DEFAULT_QP_MAX                  51
@@ -273,10 +273,11 @@
 #define DEFAULT_ENABLE_SATQD            1
 #define DEFAULT_MIN_SAD_ENABLE          0
 #define DEFAULT_MIN_SAD_DISABLE         -1
-#define DEFAULT_SRCH_RNG_X              16
-#define DEFAULT_SRCH_RNG_Y              16
+#define DEFAULT_SRCH_RNG_X              64
+#define DEFAULT_SRCH_RNG_Y              48
 #define DEFAULT_I_INTERVAL              30
-#define DEFAULT_IDR_INTERVAL            1200
+#define DEFAULT_IDR_INTERVAL            1000
+#define DEFAULT_B_FRAMES                0
 #define DEFAULT_DISABLE_DEBLK_LEVEL     0
 #define DEFAULT_PROFILE                 IV_PROFILE_BASE
 #define DEFAULT_MIN_INTRA_FRAME_RATE    1
@@ -284,10 +285,10 @@
 #define DEFAULT_MIN_BUFFER_DELAY        30
 #define DEFAULT_MAX_BUFFER_DELAY        20000
 #define DEFAULT_STRIDE                  0
+#define DEFAULT_ENC_SPEED_PRESET        IVE_USER_DEFINED
 #define DEFAULT_PRE_ENC_ME              0
 #define DEFAULT_PRE_ENC_IPE             0
 #define DEFAULT_ENTROPY_CODING_MODE     0
-#define DEFAULT_CONSTRAINED_INTRAPRED   0
 
 /** Maximum number of entries in input buffer list */
 #define MAX_INP_BUF_LIST_ENTRIES         32
@@ -373,15 +374,15 @@
 /* [0 - 00 - 00110] */
 #define NAL_SEI_FIRST_BYTE 0x06
 
-/**
-******************************************************************************
- * @brief h264qp and linear qp map
-******************************************************************************
-*/
+#define H264_ALLOC_INTER_FRM_INTV        2
+
 #define H264_MPEG_QP_MAP    255
+
 #define MPEG2_QP_ELEM       (H264_MPEG_QP_MAP + 1)
 #define H264_QP_ELEM        (MAX_H264_QP + 1)
 
+#define H264_INIT_QUANT_I                26
+#define H264_INIT_QUANT_P                34
 
 /*****************************************************************************/
 /* Enums                                                                     */


### PR DESCRIPTION
This reverts commit 7f0c8a545b466bd93e440732d9b0ac484757062e.

Reason: This changes behavior w.r.t. frame rates in terms of units.