### PR TITLE
svcenc: Integer overflow in irc_ba_get_cur_frm_est_texture_bits

### DIFF
--- a/encoder/svc/isvce_encode.c
+++ b/encoder/svc/isvce_encode.c
@@ -249,9 +249,7 @@ WORD32 isvce_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
                             ps_video_encode_op->s_ive_op.u4_error_code, IV_FAIL);
     }
 
-    error_status =
-        isvce_svc_frame_params_validate(ps_codec->s_rate_control.apps_rate_control_api,
-                                        ps_codec->s_cfg.s_svc_params.u1_num_spatial_layers);
+    error_status = isvce_svc_frame_params_validate(ps_codec, ps_video_encode_ip);
     SET_ERROR_ON_RETURN(error_status, IVE_FATALERROR, ps_video_encode_op->s_ive_op.u4_error_code,
                         IV_FAIL);
 

--- a/encoder/svc/isvce_utils.h
+++ b/encoder/svc/isvce_utils.h
@@ -182,8 +182,8 @@ extern WORD32 isvce_svc_inp_params_validate(isvce_init_ip_t *ps_ip, isvce_cfg_pa
 
 extern WORD32 isvce_svc_rc_params_validate(isvce_cfg_params_t *ps_cfg);
 
-extern WORD32 isvce_svc_frame_params_validate(
-    rate_control_api_t *aps_rate_control_api[MAX_NUM_SPATIAL_LAYERS], UWORD8 u1_num_spatial_layers);
+extern WORD32 isvce_svc_frame_params_validate(isvce_codec_t *ps_codec,
+                                              isvce_video_encode_ip_t *ps_video_encode_ip);
 
 extern WORD32 isvce_get_total_svc_au_buf_size(svc_inp_params_t *ps_svc_inp_params,
                                               WORD32 i4_pic_size, WORD32 i4_level,


### PR DESCRIPTION
RC was incorrectly handling cases where 'I_TO_P_BIT_RATIO' multiplied by 'i4_est_texture_bits_for_frm' (which stores the estimated texture bits for the current frame), exceeded the range of int32_t. This has been fixed by clipping the product of the two quantities above.

Bug = ossfuzz:63175
Test: svc_enc_fuzzer