### PR TITLE
libavcenc: modified the way static and dynamic params are parsed

### DIFF
--- a/encoder/ih264e_encode.c
+++ b/encoder/ih264e_encode.c
@@ -289,7 +289,11 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
     /* initialize codec ctxt with default params for the first encode api call */
     if (ps_codec->i4_encode_api_call_cnt == 0)
     {
-        ih264e_codec_init(ps_codec);
+        error_status = ih264e_codec_init(
+                        ps_codec, ps_video_encode_ip->s_ive_ip.u4_timestamp_low,
+                        ps_video_encode_ip->s_ive_ip.u4_timestamp_high);
+        SET_ERROR_ON_RETURN(
+                    error_status, IVE_FATALERROR, ps_video_encode_op->s_ive_op.u4_error_code, IV_FAIL);
     }
 
     /* parse configuration params */
@@ -306,9 +310,9 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
             {
                 error_status = ih264e_codec_update_config(ps_codec, ps_cfg);
                 SET_ERROR_ON_RETURN(error_status,
-                                    IVE_FATALERROR,
-                                    ps_video_encode_op->s_ive_op.u4_error_code,
-                                    IV_FAIL);
+                                    ((error_status == IH264E_UNSUPPORTED_DYNAMIC_CONFIG_REQUEST) ?
+                                                    IVE_UNSUPPORTEDPARAM : IVE_FATALERROR),
+                                    ps_video_encode_op->s_ive_op.u4_error_code, IV_FAIL);
 
                 ps_cfg->u4_is_valid = 0;
             }

--- a/encoder/ih264e_error.h
+++ b/encoder/ih264e_error.h
@@ -255,6 +255,12 @@ typedef enum
     /**Invalid shutter interval info sei params. Does not match H264 sii spec requirements*/
     IH264E_SEI_SII_FAILED_TO_MATCH_SPEC_COND = IH264E_CODEC_ERROR_START + 0x38,
 
+    /** unsupported config update, recoverable error */
+    IH264E_UNSUPPORTED_DYNAMIC_CONFIG_REQUEST                       = IH264E_CODEC_ERROR_START + 0x39,
+
+    /** unsupported config update, fatal error */
+    IH264E_FATAL_DYNAMIC_CONFIG_REQUEST                             = IH264E_CODEC_ERROR_START + 0x3A,
+
     /**max failure error code to ensure enum is 32 bits wide */
     IH264E_FAIL                                                     = -1,
 

--- a/encoder/ih264e_utils.h
+++ b/encoder/ih264e_utils.h
@@ -69,7 +69,9 @@ IH264E_ERROR_T ih264e_init_air_map(codec_t *ps_codec);
 
 void ih264e_speed_preset_side_effects(codec_t *ps_codec);
 
-IH264E_ERROR_T ih264e_codec_init(codec_t *ps_codec);
+IH264E_ERROR_T ih264e_codec_init(codec_t *ps_codec,
+                                 UWORD32 u4_timestamp_low,
+                                 UWORD32 u4_timestamp_high);
 
 IH264E_ERROR_T ih264e_pic_init(codec_t *ps_codec, inp_buf_t *ps_inp_buf);
 


### PR DESCRIPTION
During initialization, after parsing a config param, it is applied right away. Speed preset configuration call has certain side effects. This call can overrite earlier config calls. Once overwritten, if speed preset config is reverted by queuing one more config call, there is no way to restore old state.

This change modifies the way static params are applied. First it parses all the params in the list and then applies at once.

Also, restrict dynamic param update to bitrate and force intra calls

Change-Id: Ifee9130f0021f77905aea67832abc049337978e3