### PR TITLE
svcenc: Integer overflow in irc_ba_get_cur_frm_est_texture_bits

### DIFF
--- a/encoder/svc/isvce_utils.h
+++ b/encoder/svc/isvce_utils.h
@@ -180,8 +180,6 @@ extern WORD32 isvce_svc_au_props_validate(svc_inp_params_t *ps_svc_inp_params, U
 
 extern WORD32 isvce_svc_inp_params_validate(isvce_init_ip_t *ps_ip, isvce_cfg_params_t *ps_cfg);
 
-extern WORD32 isvce_svc_rc_params_validate(isvce_cfg_params_t *ps_cfg);
-
 extern WORD32 isvce_svc_frame_params_validate(
     rate_control_api_t *aps_rate_control_api[MAX_NUM_SPATIAL_LAYERS], UWORD8 u1_num_spatial_layers);
 


### PR DESCRIPTION
'isvce_svc_rc_params_validate' was not being invoked prior to
call to 'isvce_rc_init'. This resulted in an erroneous state
within RC's context wherein the instantaneous estimate for the
texture bits for the frame being processed exceeded INT_MAX.
'isvce_svc_rc_params_validate' has code that detects such a
state and is now being correctly invoked where apprpriate.

Bug = ossfuzz:63175
Test: svc_enc_fuzzer