### PR TITLE
Enable unit tests in postsubmit

### DIFF
--- a/TEST_MAPPING
+++ b/TEST_MAPPING
@@ -1,0 +1,5 @@
+{
+    "postsubmit": [
+        { "name": "AvcEncTest" }
+    ]
+}

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -26,16 +26,17 @@ package {
 cc_test {
     name: "AvcEncTest",
     gtest: true,
+    test_suites: ["device-tests"],
 
-    srcs : [ "AvcEncTest.cpp" ],
+    srcs: ["AvcEncTest.cpp"],
 
     shared_libs: [
         "libutils",
-        "liblog"
+        "liblog",
     ],
 
     static_libs: [
-        "libavcenc"
+        "libavcenc",
     ],
 
     cflags: [


### PR DESCRIPTION
After some time of running these in postsubmit, these will be changed to presubmit.

- Added AvcEncTest to device-tests test suite
- Also run bpfmt on test/Android.bp

Bug: 304383609
Test: atest AvcEncTest
Change-Id: Ic18b25d8ed27313b6e3a984259af1215ae240c9e