### PR TITLE
mvcdec: Heap overflow in 'ih264d_read_coeff4x4_cabac'

### DIFF
--- a/decoder/mvc/imvcd_api.c
+++ b/decoder/mvc/imvcd_api.c
@@ -733,7 +733,13 @@ static IV_API_CALL_STATUS_T imvcd_view_decode(iv_obj_t *ps_dec_hdl, imvcd_video_
 
         if(i4_nalu_length)
         {
-            UWORD32 u4_nalu_buf_size = ((UWORD32) i4_nalu_length) + 8;
+            /* In some erroneous fuzzer bistreams, the slice data requires more
+              parsing than what was implied by the distance between successive
+              start codes.The primary culprit is the NEXTBITS macro which requires
+              reading 4 additional bytes of the bitstream buffer.To alleviate
+              this, 4 bytes per 4x4 TU have been additionally allocated to the
+              bitstream buffer. */
+            UWORD32 u4_nalu_buf_size = ((UWORD32) i4_nalu_length) + 8 + 4 * 16;
 
             if(u4_nalu_buf_size > u4_bitstream_buf_size)
             {


### PR DESCRIPTION
In some erroneous fuzzer bistreams, the slice data requires more parsing than what was implied by the distance between successive start codes. The primary culprit is the NEXTBITS macro which requires reading 4 additional bytes of the bitstream buffer. To alleviate this, 4 bytes per 4x4 TU have been additionally allocated to the bitstream buffer.

Bug = ossfuzz:66989
Test: mvc_dec_fuzzer