### PR TITLE
Remove useless `neon:` clause.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -93,15 +93,7 @@ cc_defaults {
 
             cflags: [
                 "-DARM",
-                // These will be overriden by armv7_a_neon
-                "-DDISABLE_NEON",
             ],
-
-            neon: {
-                cflags: [
-                    "-UDISABLE_NEON",
-                ],
-            },
         },
 
         arm64: {
@@ -187,18 +179,8 @@ cc_defaults {
             ],
             cflags: [
                 "-DARM",
-                // These will be overriden by armv7_a_neon
-                "-DDISABLE_NEON",
-                "-DDEFAULT_ARCH=D_ARCH_ARM_NONEON",
+                "-DDEFAULT_ARCH=D_ARCH_ARM_A9Q",
             ],
-
-            neon: {
-                cflags: [
-                    "-UDISABLE_NEON",
-                    "-UDEFAULT_ARCH",
-                    "-DDEFAULT_ARCH=D_ARCH_ARM_A9Q",
-                ],
-            },
         },
 
         arm64: {
@@ -316,36 +298,31 @@ cc_library_static {
             srcs: [
                 "common/arm/ih264_arm_memory_barrier.s",
                 "decoder/arm/ih264d_function_selector.c",
+                "common/arm/ih264_deblk_chroma_a9.s",
+                "common/arm/ih264_deblk_luma_a9.s",
+                "common/arm/ih264_default_weighted_pred_a9q.s",
+                "common/arm/ih264_ihadamard_scaling_a9.s",
+                "common/arm/ih264_inter_pred_chroma_a9q.s",
+                "common/arm/ih264_inter_pred_filters_luma_horz_a9q.s",
+                "common/arm/ih264_inter_pred_filters_luma_vert_a9q.s",
+                "common/arm/ih264_inter_pred_luma_copy_a9q.s",
+                "common/arm/ih264_inter_pred_luma_horz_hpel_vert_hpel_a9q.s",
+                "common/arm/ih264_inter_pred_luma_horz_hpel_vert_qpel_a9q.s",
+                "common/arm/ih264_inter_pred_luma_horz_qpel_a9q.s",
+                "common/arm/ih264_inter_pred_luma_horz_qpel_vert_hpel_a9q.s",
+                "common/arm/ih264_inter_pred_luma_horz_qpel_vert_qpel_a9q.s",
+                "common/arm/ih264_inter_pred_luma_vert_qpel_a9q.s",
+                "common/arm/ih264_intra_pred_chroma_a9q.s",
+                "common/arm/ih264_intra_pred_luma_16x16_a9q.s",
+                "common/arm/ih264_intra_pred_luma_4x4_a9q.s",
+                "common/arm/ih264_intra_pred_luma_8x8_a9q.s",
+                "common/arm/ih264_iquant_itrans_recon_a9.s",
+                "common/arm/ih264_iquant_itrans_recon_dc_a9.s",
+                "common/arm/ih264_padding_neon.s",
+                "common/arm/ih264_weighted_bi_pred_a9q.s",
+                "common/arm/ih264_weighted_pred_a9q.s",
+                "decoder/arm/ih264d_function_selector_a9q.c",
             ],
-
-            neon: {
-                srcs: [
-                    "common/arm/ih264_deblk_chroma_a9.s",
-                    "common/arm/ih264_deblk_luma_a9.s",
-                    "common/arm/ih264_default_weighted_pred_a9q.s",
-                    "common/arm/ih264_ihadamard_scaling_a9.s",
-                    "common/arm/ih264_inter_pred_chroma_a9q.s",
-                    "common/arm/ih264_inter_pred_filters_luma_horz_a9q.s",
-                    "common/arm/ih264_inter_pred_filters_luma_vert_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_copy_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_horz_hpel_vert_hpel_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_horz_hpel_vert_qpel_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_horz_qpel_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_horz_qpel_vert_hpel_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_horz_qpel_vert_qpel_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_vert_qpel_a9q.s",
-                    "common/arm/ih264_intra_pred_chroma_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_16x16_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_4x4_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_8x8_a9q.s",
-                    "common/arm/ih264_iquant_itrans_recon_a9.s",
-                    "common/arm/ih264_iquant_itrans_recon_dc_a9.s",
-                    "common/arm/ih264_padding_neon.s",
-                    "common/arm/ih264_weighted_bi_pred_a9q.s",
-                    "common/arm/ih264_weighted_pred_a9q.s",
-                    "decoder/arm/ih264d_function_selector_a9q.c",
-                ],
-            },
         },
 
         arm64: {
@@ -537,36 +514,31 @@ cc_library_static {
             srcs: [
                 "common/arm/ih264_arm_memory_barrier.s",
                 "encoder/arm/ih264e_function_selector.c",
+                "common/arm/ih264_deblk_chroma_a9.s",
+                "common/arm/ih264_deblk_luma_a9.s",
+                "common/arm/ih264_ihadamard_scaling_a9.s",
+                "common/arm/ih264_inter_pred_chroma_a9q.s",
+                "common/arm/ih264_inter_pred_filters_luma_horz_a9q.s",
+                "common/arm/ih264_inter_pred_filters_luma_vert_a9q.s",
+                "common/arm/ih264_inter_pred_luma_bilinear_a9q.s",
+                "common/arm/ih264_inter_pred_luma_copy_a9q.s",
+                "common/arm/ih264_intra_pred_chroma_a9q.s",
+                "common/arm/ih264_intra_pred_luma_16x16_a9q.s",
+                "common/arm/ih264_intra_pred_luma_4x4_a9q.s",
+                "common/arm/ih264_intra_pred_luma_8x8_a9q.s",
+                "common/arm/ih264_iquant_itrans_recon_a9.s",
+                "common/arm/ih264_iquant_itrans_recon_dc_a9.s",
+                "common/arm/ih264_mem_fns_neon.s",
+                "common/arm/ih264_padding_neon.s",
+                "common/arm/ih264_resi_trans_quant_a9.s",
+                "encoder/arm/ih264e_evaluate_intra16x16_modes_a9q.s",
+                "encoder/arm/ih264e_evaluate_intra4x4_modes_a9q.s",
+                "encoder/arm/ih264e_evaluate_intra_chroma_modes_a9q.s",
+                "encoder/arm/ih264e_fmt_conv.s",
+                "encoder/arm/ih264e_function_selector_a9q.c",
+                "encoder/arm/ih264e_half_pel.s",
+                "encoder/arm/ime_distortion_metrics_a9q.s",
             ],
-
-            neon: {
-                srcs: [
-                    "common/arm/ih264_deblk_chroma_a9.s",
-                    "common/arm/ih264_deblk_luma_a9.s",
-                    "common/arm/ih264_ihadamard_scaling_a9.s",
-                    "common/arm/ih264_inter_pred_chroma_a9q.s",
-                    "common/arm/ih264_inter_pred_filters_luma_horz_a9q.s",
-                    "common/arm/ih264_inter_pred_filters_luma_vert_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_bilinear_a9q.s",
-                    "common/arm/ih264_inter_pred_luma_copy_a9q.s",
-                    "common/arm/ih264_intra_pred_chroma_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_16x16_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_4x4_a9q.s",
-                    "common/arm/ih264_intra_pred_luma_8x8_a9q.s",
-                    "common/arm/ih264_iquant_itrans_recon_a9.s",
-                    "common/arm/ih264_iquant_itrans_recon_dc_a9.s",
-                    "common/arm/ih264_mem_fns_neon.s",
-                    "common/arm/ih264_padding_neon.s",
-                    "common/arm/ih264_resi_trans_quant_a9.s",
-                    "encoder/arm/ih264e_evaluate_intra16x16_modes_a9q.s",
-                    "encoder/arm/ih264e_evaluate_intra4x4_modes_a9q.s",
-                    "encoder/arm/ih264e_evaluate_intra_chroma_modes_a9q.s",
-                    "encoder/arm/ih264e_fmt_conv.s",
-                    "encoder/arm/ih264e_function_selector_a9q.c",
-                    "encoder/arm/ih264e_half_pel.s",
-                    "encoder/arm/ime_distortion_metrics_a9q.s",
-                ],
-            },
         },
 
         arm64: {
@@ -720,20 +692,15 @@ cc_library_static {
 
             srcs: [
                 "encoder/arm/svc/isvce_function_selector.c",
+                "common/arm/svc/isvc_intra_sampling_neon.c",
+                "common/arm/svc/isvc_iquant_itrans_recon_neon.c",
+                "common/arm/svc/isvc_mem_fns_neon.c",
+                "common/arm/svc/isvc_resi_trans_quant_neon.c",
+                "encoder/arm/svc/isvce_downscaler_neon.c",
+                "encoder/arm/svc/isvce_function_selector_a9q.c",
+                "encoder/arm/svc/isvce_rc_utils_neon.c",
+                "encoder/arm/svc/isvce_residual_pred_neon.c",
             ],
-
-            neon: {
-                srcs: [
-                    "common/arm/svc/isvc_intra_sampling_neon.c",
-                    "common/arm/svc/isvc_iquant_itrans_recon_neon.c",
-                    "common/arm/svc/isvc_mem_fns_neon.c",
-                    "common/arm/svc/isvc_resi_trans_quant_neon.c",
-                    "encoder/arm/svc/isvce_downscaler_neon.c",
-                    "encoder/arm/svc/isvce_function_selector_a9q.c",
-                    "encoder/arm/svc/isvce_rc_utils_neon.c",
-                    "encoder/arm/svc/isvce_residual_pred_neon.c",
-                ],
-            },
         },
 
         arm64: {
@@ -864,19 +831,14 @@ cc_library_static {
         arm: {
             srcs: [
                 "decoder/arm/svc/isvcd_function_selector.c",
+                "decoder/arm/svc/isvcd_function_selector_neon.c",
+                "decoder/arm/svc/isvcd_intra_resamp_neon.c",
+                "decoder/arm/svc/isvcd_iquant_itrans_neon.c",
+                "decoder/arm/svc/isvcd_iquant_itrans_residual_neon.c",
+                "decoder/arm/svc/isvcd_iquant_itrans_residual_recon_neon.c",
+                "decoder/arm/svc/isvcd_pred_residual_recon_neon.c",
+                "decoder/arm/svc/isvcd_residual_resamp_neon.c",
             ],
-
-            neon: {
-                srcs: [
-                    "decoder/arm/svc/isvcd_function_selector_neon.c",
-                    "decoder/arm/svc/isvcd_intra_resamp_neon.c",
-                    "decoder/arm/svc/isvcd_iquant_itrans_neon.c",
-                    "decoder/arm/svc/isvcd_iquant_itrans_residual_neon.c",
-                    "decoder/arm/svc/isvcd_iquant_itrans_residual_recon_neon.c",
-                    "decoder/arm/svc/isvcd_pred_residual_recon_neon.c",
-                    "decoder/arm/svc/isvcd_residual_resamp_neon.c",
-                ],
-            },
         },
 
         arm64: {
@@ -928,4 +890,3 @@ cc_library_static {
         },
     },
 }
-


### PR DESCRIPTION
There hasn't been a non-neon platform build in years.

Bug: 330929681
Test: Builds
Change-Id: I712c2111722a17ecf55ab36e8069275c74379256