### PR TITLE
libavc : Fix mutex initialization index in apv_proc_start_mutex

### DIFF
--- a/decoder/ih264d_api.c
+++ b/decoder/ih264d_api.c
@@ -1628,7 +1628,7 @@ WORD32 ih264d_allocate_static_bufs(iv_obj_t **dec_hdl, void *pv_api_ip, void *pv
             ps_dec->apv_proc_done_mutex[i] =
                             (UWORD8 *)pv_buf + ((2 * i + 1) * mutex_size);
 
-            ret = ithread_mutex_init(ps_dec->apv_proc_start_mutex[0]);
+            ret = ithread_mutex_init(ps_dec->apv_proc_start_mutex[i]);
             RETURN_IF((ret != IV_SUCCESS), ret);
 
             ret = ithread_mutex_init(ps_dec->apv_proc_done_mutex[i]);


### PR DESCRIPTION
- Changed hardcoded index [0] to loop variable [i] in ithread_mutex_init call
- Ensures correct initialization of both mutexes in the loop

Test: ./avcdec