### PR TITLE
libavc: remove unused KEEP_THREADS_ACTIVE flag in Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -161,8 +161,6 @@ cc_defaults {
         "-Werror",
         "-Wno-unused-variable",
         "-Wno-null-pointer-arithmetic",
-        // #KEEP_THREAD_ACTIVE is experimental
-        "-UKEEP_THREADS_ACTIVE",
     ],
     vendor_available: true,
     host_supported: true,
@@ -785,6 +783,9 @@ cc_library_static {
 cc_library_static {
     name: "libsvcdec",
     defaults: ["libavc_dec_defaults"],
+    cflags: [
+        "-UKEEP_THREADS_ACTIVE",
+    ],
     whole_static_libs: [
         "libavcdec",
     ],


### PR DESCRIPTION
Bug: 376303949
Test: Build and review