### PR TITLE
avcenc: add support for KEEP_THREADS_ACTIVE

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -83,6 +83,7 @@ cc_defaults {
         "-Wall",
         "-Werror",
         "-Wno-error=constant-conversion",
+        "-UKEEP_THREADS_ACTIVE",
     ],
     arch: {
         arm: {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(AVC_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 option(ENABLE_MVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_SVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_TESTS "Enables gtest based unit tests" OFF)
+option(KEEP_THREADS_ACTIVE "Enable KEEP THREADS ACTIVE" OFF)
 
 if("${AVC_ROOT}" STREQUAL "${AVC_CONFIG_DIR}")
   message(

--- a/common/ih264_list.c
+++ b/common/ih264_list.c
@@ -557,3 +557,32 @@ IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf, WORD32 blocking)
 
     return ret;
 }
+
+#ifdef KEEP_THREADS_ACTIVE
+/**
+*******************************************************************************
+*
+* @brief
+*   Gets the number of jobs
+*
+* @par   Description
+*   Gets the number of jobs to be processed in job queue context.
+*
+* @param[in] ps_list
+*   Job Queue context
+*
+* @returns 0 if lock unlock fails else number of jobs to be processed
+*
+* @remarks
+*
+*******************************************************************************
+*/
+WORD32 ih264_get_job_count_in_list(list_t *ps_list)
+{
+    WORD32 jobs = 0;
+    RETURN_IF((ih264_list_lock(ps_list) != IH264_SUCCESS), 0);
+    jobs = ps_list->i4_buf_wr_idx - ps_list->i4_buf_rd_idx;
+    RETURN_IF((ih264_list_unlock(ps_list) != IH264_SUCCESS), 0);
+    return jobs;
+}
+#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ih264_list.h
+++ b/common/ih264_list.h
@@ -100,4 +100,10 @@ IH264_ERROR_T ih264_list_queue(list_t *ps_list, void *pv_buf, WORD32 blocking);
 IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf,
                                  WORD32 blocking);
 
+#ifdef KEEP_THREADS_ACTIVE
+
+WORD32 ih264_get_job_count_in_list(list_t *ps_list);
+
+#endif /* KEEP_THREADS_ACTIVE */
+
 #endif /* _IH264_LIST_H_ */

--- a/common/ithread.c
+++ b/common/ithread.c
@@ -234,3 +234,15 @@ WORD32 ithread_cond_signal(void *cond)
 {
     return pthread_cond_signal((pthread_cond_t *)cond);
 }
+
+#ifdef KEEP_THREADS_ACTIVE
+UWORD32 ithread_get_cond_size(void)
+{
+    return sizeof(pthread_cond_t);
+}
+
+WORD32  ithread_cond_broadcast(void *cond)
+{
+    return pthread_cond_broadcast((pthread_cond_t *)cond);
+}
+#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ithread.h
+++ b/common/ithread.h
@@ -95,4 +95,12 @@ WORD32  ithread_cond_wait(void *cond, void *mutex);
 
 WORD32  ithread_cond_signal(void *cond);
 
+#ifdef KEEP_THREADS_ACTIVE
+
+UWORD32 ithread_get_cond_size(void);
+
+WORD32  ithread_cond_broadcast(void *cond);
+
+#endif /* KEEP_THREADS_ACTIVE */
+
 #endif /* _ITHREAD_H_ */

--- a/encoder/ih264e_api.c
+++ b/encoder/ih264e_api.c
@@ -3494,6 +3494,29 @@ static WORD32 ih264e_fill_num_mem_rec(void *pv_api_ip, void *pv_api_op)
     }
     DEBUG("\nMemory record Id %d = %d \n", MEM_REC_SLICE_MAP, ps_mem_rec->u4_mem_size);
 
+#ifdef KEEP_THREADS_ACTIVE
+    /************************************************************************
+    * Request memory for thread pool context                            *
+    ***********************************************************************/
+    ps_mem_rec = &ps_mem_rec_base[MEM_REC_THREAD_POOL];
+    {
+        /* total size of the mem record */
+        WORD32 total_size = 0;
+
+        /* mutex size */
+        total_size += ALIGN128(ithread_get_mutex_lock_size());
+
+        /* condition variable size */
+        total_size += ALIGN128(ithread_get_cond_size());
+
+        /* size for thread handles array */
+        total_size += (MAX_PROCESS_THREADS * ALIGN128(ithread_get_handle_size()));
+
+        /* Store the total calculated size in memory record */
+        ps_mem_rec->u4_mem_size = total_size;
+    }
+    DEBUG("\nMemory record Id %d = %d \n", MEM_REC_THREAD_POOL, ps_mem_rec->u4_mem_size);
+#else
     /************************************************************************
      * Request memory to hold thread handles for each processing thread     *
      ************************************************************************/
@@ -3504,6 +3527,7 @@ static WORD32 ih264e_fill_num_mem_rec(void *pv_api_ip, void *pv_api_op)
         ps_mem_rec->u4_mem_size = MAX_PROCESS_THREADS * handle_size;
     }
     DEBUG("\nMemory record Id %d = %d \n", MEM_REC_THREAD_HANDLE, ps_mem_rec->u4_mem_size);
+#endif /* KEEP_THREADS_ACTIVE */
 
     /************************************************************************
      * Request memory to hold mutex for control calls                       *
@@ -4417,6 +4441,29 @@ static WORD32 ih264e_init_mem_rec(iv_obj_t *ps_codec_obj,
         }
     }
 
+#ifdef KEEP_THREADS_ACTIVE
+    ps_mem_rec = &ps_mem_rec_base[MEM_REC_THREAD_POOL];
+    {
+        /* temp var */
+        WORD32 i = 0;
+
+        UWORD8 *pu1_buf = (UWORD8 *)ps_mem_rec->pv_base;
+
+        /* Assign mutex pointer */
+        ps_codec->s_thread_pool.pv_thread_pool_mutex = (void *)pu1_buf;
+        pu1_buf += ALIGN128(ithread_get_mutex_lock_size());
+
+        /* Assign condition variable pointer */
+        ps_codec->s_thread_pool.pv_thread_pool_cond = (void *)pu1_buf;
+        pu1_buf += ALIGN128(ithread_get_cond_size());
+
+        for (i= 0; i < MAX_PROCESS_THREADS; i++)
+        {
+            ps_codec->s_thread_pool.apv_threads[i] = (void *)pu1_buf;
+            pu1_buf += ALIGN128(ithread_get_handle_size());
+        }
+    }
+#else
     ps_mem_rec = &ps_mem_rec_base[MEM_REC_THREAD_HANDLE];
     {
         WORD32 handle_size = ithread_get_handle_size();
@@ -4427,6 +4474,7 @@ static WORD32 ih264e_init_mem_rec(iv_obj_t *ps_codec_obj,
                             + (i * handle_size);
         }
     }
+#endif /* KEEP_THREADS_ACTIVE */
 
     ps_mem_rec = &ps_mem_rec_base[MEM_REC_CTL_MUTEX];
     {
@@ -4940,8 +4988,12 @@ static WORD32 ih264e_retrieve_memrec(iv_obj_t *ps_codec_obj,
         return IV_FAIL;
     }
 
+#ifdef KEEP_THREADS_ACTIVE
+    ih264e_thread_pool_shutdown(ps_codec);
+#else
     /* join threads upon at end of sequence */
     ih264e_join_threads(ps_codec);
+#endif /* KEEP_THREADS_ACTIVE */
 
     /* collect list of memory records used by the encoder library */
     memcpy(ps_ip->s_ive_ip.ps_mem_rec, ps_codec->ps_mem_rec_backup,

--- a/encoder/ih264e_defs.h
+++ b/encoder/ih264e_defs.h
@@ -469,10 +469,17 @@ enum
      */
     MEM_REC_SLICE_MAP,
 
+#ifdef KEEP_THREADS_ACTIVE
+    /**
+     * Holds thread pool
+     */
+    MEM_REC_THREAD_POOL,
+#else
     /**
      * Holds thread handles
      */
     MEM_REC_THREAD_HANDLE,
+#endif /* KEEP_THREADS_ACTIVE */
 
     /**
      * Holds control call mutex

--- a/encoder/ih264e_master.h
+++ b/encoder/ih264e_master.h
@@ -41,8 +41,23 @@
 /*****************************************************************************/
 /* Function Declarations                                                     */
 /*****************************************************************************/
+#ifdef KEEP_THREADS_ACTIVE
+
+WORD32 ih264e_thread_pool_init(codec_t *ps_codec);
+
+WORD32 ih264e_thread_pool_shutdown(codec_t *ps_codec);
+
+static WORD32 ih264e_thread_worker(void *pv_proc);
+
+WORD32 ih264e_thread_pool_activate(codec_t *ps_codec);
+
+WORD32 ih264e_thread_pool_sync(codec_t *ps_codec);
+
+#else
 
 void ih264e_join_threads(codec_t *ps_codec);
+
+#endif /* KEEP_THREADS_ACTIVE */
 
 void ih264e_compute_quality_stats(process_ctxt_t *ps_proc);
 

--- a/encoder/ih264e_structs.h
+++ b/encoder/ih264e_structs.h
@@ -1155,6 +1155,54 @@ typedef struct
 
 } entropy_ctxt_t;
 
+#ifdef KEEP_THREADS_ACTIVE
+/**
+ ******************************************************************************
+ *  @brief     The thread_pool_t structure manages a pool of worker threads,
+ *             providing synchronization mechanisms for job scheduling, codec
+ *             processing, and controlled execution flow.
+ ******************************************************************************
+ */
+typedef struct
+{
+    /**
+     * Array of worker thread handles
+     */
+    void *apv_threads[MAX_PROCESS_THREADS];
+
+    /**
+     * Mutex for synchronizing access to the thread pool
+     */
+    void *pv_thread_pool_mutex;
+
+    /**
+     * Condition variable for signaling worker threads
+     */
+    void *pv_thread_pool_cond;
+
+    /**
+     * Flag indicating whether the thread pool is initialized
+     */
+    WORD32 i4_init_done;
+
+    /**
+     * Flag indicating whether the thread pool should be terminated
+     */
+    WORD32 i4_end_of_stream;
+
+    /**
+     * Flag indicating the availability of a new frame for processing
+     */
+    WORD32 i4_has_frame;
+
+    /**
+     * Number of threads currently processing tasks
+     */
+    WORD32 i4_working_threads;
+
+} thread_pool_t;
+#endif /* KEEP_THREADS_ACTIVE */
+
 /**
 ******************************************************************************
 *  @brief      macro block info.
@@ -2414,6 +2462,13 @@ struct _codec_t
      */
      void *pv_out_buf_mgr_base;
 
+#ifdef KEEP_THREADS_ACTIVE
+    /**
+     * Thread pool
+     * */
+    thread_pool_t s_thread_pool;
+#endif /* KEEP_THREADS_ACTIVE */
+
     /**
      * Buffer manager for output buffers
      */
@@ -2500,10 +2555,12 @@ struct _codec_t
      */
     process_ctxt_t as_process[MAX_PROCESS_CTXT];
 
+#ifndef KEEP_THREADS_ACTIVE
     /**
      * Thread handle for each of the processing threads
      */
     void *apv_proc_thread_handle[MAX_PROCESS_THREADS];
+#endif
 
     /**
      * Structure for global PSNR

--- a/encoder/libavcenc.cmake
+++ b/encoder/libavcenc.cmake
@@ -90,3 +90,7 @@ add_library(libavcenc STATIC ${LIBAVC_COMMON_SRCS} ${LIBAVC_COMMON_ASMS}
                              ${LIBAVCENC_SRCS} ${LIBAVCENC_ASMS})
 
 target_compile_definitions(libavcenc PRIVATE N_MB_ENABLE)
+
+if(KEEP_THREADS_ACTIVE)
+  target_compile_definitions(libavcenc PRIVATE KEEP_THREADS_ACTIVE)
+endif()


### PR DESCRIPTION
Currently avc encoder creates desired number of threads at the start of every frame and joins after frame is processed. This change modifies the thread creation part. Now the threads are created at the start of the sequence. Kept alive through out the sequence and joined at the end of the sequence. This helps in reduction of thread creation and deletion overhead.

This change does not effect the encoded bitstream. That is, encoded output with this change is same as encoded output without this change.

Bug:288998933
Test: avcenc -c enc.cfg