### PR TITLE
avcenc: add support for KEEP_THREADS_ACTIVE

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -83,6 +83,7 @@ cc_defaults {
         "-Wall",
         "-Werror",
         "-Wno-error=constant-conversion",
+        "-UKEEP_THREADS_ACTIVE",
     ],
     arch: {
         arm: {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(AVC_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 option(ENABLE_MVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_SVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_TESTS "Enables gtest based unit tests" OFF)
+option(KEEP_THREADS_ACTIVE "Enable KEEP THREADS ACTIVE" OFF)
 
 if("${AVC_ROOT}" STREQUAL "${AVC_CONFIG_DIR}")
   message(

--- a/common/ih264_list.c
+++ b/common/ih264_list.c
@@ -557,3 +557,32 @@ IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf, WORD32 blocking)
 
     return ret;
 }
+
+#ifdef KEEP_THREADS_ACTIVE
+/**
+*******************************************************************************
+*
+* @brief
+*   Gets the number of jobs
+*
+* @par   Description
+*   Gets the number of jobs to be processed in job queue context.
+*
+* @param[in] ps_list
+*   Job Queue context
+*
+* @returns 0 if lock unlock fails else number of jobs to be processed
+*
+* @remarks
+*
+*******************************************************************************
+*/
+WORD32 ih264_get_job_count_in_list(list_t *ps_list)
+{
+    WORD32 jobs = 0;
+    RETURN_IF((ih264_list_lock(ps_list) != IH264_SUCCESS), 0);
+    jobs = ps_list->i4_buf_wr_idx - ps_list->i4_buf_rd_idx;
+    RETURN_IF((ih264_list_unlock(ps_list) != IH264_SUCCESS), 0);
+    return jobs;
+}
+#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ih264_list.h
+++ b/common/ih264_list.h
@@ -100,4 +100,10 @@ IH264_ERROR_T ih264_list_queue(list_t *ps_list, void *pv_buf, WORD32 blocking);
 IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf,
                                  WORD32 blocking);
 
+#ifdef KEEP_THREADS_ACTIVE
+
+WORD32 ih264_get_job_count_in_list(list_t *ps_list);
+
+#endif /* KEEP_THREADS_ACTIVE */
+
 #endif /* _IH264_LIST_H_ */

--- a/common/ithread.c
+++ b/common/ithread.c
@@ -234,3 +234,15 @@ WORD32 ithread_cond_signal(void *cond)
 {
     return pthread_cond_signal((pthread_cond_t *)cond);
 }
+
+#ifdef KEEP_THREADS_ACTIVE
+UWORD32 ithread_get_cond_size(void)
+{
+    return sizeof(pthread_cond_t);
+}
+
+WORD32  ithread_cond_broadcast(void *cond)
+{
+    return pthread_cond_broadcast((pthread_cond_t *)cond);
+}
+#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ithread.h
+++ b/common/ithread.h
@@ -95,4 +95,12 @@ WORD32  ithread_cond_wait(void *cond, void *mutex);
 
 WORD32  ithread_cond_signal(void *cond);
 
+#ifdef KEEP_THREADS_ACTIVE
+
+UWORD32 ithread_get_cond_size(void);
+
+WORD32  ithread_cond_broadcast(void *cond);
+
+#endif /* KEEP_THREADS_ACTIVE */
+
 #endif /* _ITHREAD_H_ */

--- a/encoder/ih264e_defs.h
+++ b/encoder/ih264e_defs.h
@@ -469,10 +469,17 @@ enum
      */
     MEM_REC_SLICE_MAP,
 
+#ifdef KEEP_THREADS_ACTIVE
+    /**
+     * Holds thread pool
+     */
+    MEM_REC_THREAD_POOL,
+#else
     /**
      * Holds thread handles
      */
     MEM_REC_THREAD_HANDLE,
+#endif /* KEEP_THREADS_ACTIVE */
 
     /**
      * Holds control call mutex

--- a/encoder/ih264e_encode.c
+++ b/encoder/ih264e_encode.c
@@ -109,6 +109,286 @@
 /* Function Definitions                                                      */
 /*****************************************************************************/
 
+#ifdef KEEP_THREADS_ACTIVE
+/**
+*******************************************************************************
+*
+* @brief
+*  Initializes the thread pool for multi-threaded encoding.
+*
+* @par Description:
+*  Creates and initializes the thread pool based on the number of configured
+*  cores. It spawns worker threads and sets up necessary synchronization
+*  mechanisms.
+*
+* @param[in] ps_codec
+*  Pointer to the codec context structure.
+*
+* @returns  IV_SUCCESS on success, IV_FAIL on failure.
+*
+*******************************************************************************
+*/
+WORD32 ih264e_thread_pool_init(codec_t *ps_codec)
+{
+    /* temp var */
+    WORD32 i = 0, j = 0, ret = 0;
+
+    /* thread pool */
+    thread_pool_t *ps_pool = &ps_codec->s_thread_pool;
+
+    /* Return if already initialized */
+    if (ps_pool->i4_init_done == 1) return IV_SUCCESS;
+
+    /* initializing thread pool initialization done */
+    ps_pool->i4_init_done = 0;
+
+    /* initializing end of stream */
+    ps_pool->i4_end_of_stream = 0;
+
+    /* initializing active threads */
+    ps_pool->i4_working_threads = 0;
+
+    /* Initialize new frame ready flag */
+    ps_pool->i4_has_frame = 0;
+
+    /* thread pool mutex init */
+    ret = ithread_mutex_init(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+    if (ret != 0)
+    {
+        ih264e_thread_pool_shutdown(ps_codec);
+        return IV_FAIL;
+    }
+
+    /* thread pool conditional init */
+    ret = ithread_cond_init(ps_codec->s_thread_pool.pv_thread_pool_cond);
+    if (ret != 0)
+    {
+        ih264e_thread_pool_shutdown(ps_codec);
+        return IV_FAIL;
+    }
+
+    for (i = 1; i < ps_codec->s_cfg.u4_num_cores; i++)
+    {
+        ret = ithread_create(&ps_pool->apv_threads[i], NULL, ih264e_thread_worker,
+                             (void *) &ps_codec->as_process[i]);
+        if (ret != 0)
+        {
+            ih264e_thread_pool_shutdown(ps_codec);
+            return IV_FAIL;
+        }
+        ps_codec->ai4_process_thread_created[i] = 1;
+        ps_codec->i4_proc_thread_cnt++;
+    }
+
+    /* Thread pool initialized */
+    ps_pool->i4_init_done = 1;
+    return IV_SUCCESS;
+}
+
+/**
+*******************************************************************************
+*
+* @brief
+*  Shuts down the thread pool and cleans up resources.
+*
+* @par Description:
+*  Signals worker threads to terminate, joins all active threads, and
+*  destroys associated synchronization primitives.
+*
+* @param[in] ps_codec
+*  Pointer to the codec context structure.
+*
+* @returns  IV_SUCCESS on success, IV_FAIL on failure.
+*
+*******************************************************************************
+*/
+WORD32 ih264e_thread_pool_shutdown(codec_t *ps_codec)
+{
+    /* thread pool */
+    thread_pool_t *ps_pool = &ps_codec->s_thread_pool;
+
+    /* temp var */
+    WORD32 i = 0, j = 0;
+    WORD32 ret = IV_SUCCESS;
+
+    /* Wake all threads waiting */
+    ithread_mutex_lock(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+    ps_pool->i4_end_of_stream = 1;
+    ithread_cond_broadcast(ps_codec->s_thread_pool.pv_thread_pool_cond);
+    ithread_mutex_unlock(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+
+    /* Join threads */
+    for (i = 1; i < ps_codec->s_cfg.u4_num_cores; i++)
+    {
+        if (ps_codec->ai4_process_thread_created[i])
+        {
+            if (ithread_join(ps_pool->apv_threads[i], NULL) != 0)
+            {
+                ret = IV_FAIL;
+            }
+            ps_codec->ai4_process_thread_created[i] = 0;
+            ps_codec->i4_proc_thread_cnt--;
+        }
+    }
+
+    /* Destroy all mutexes and conds */
+    ithread_mutex_destroy(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+    ithread_cond_destroy(ps_codec->s_thread_pool.pv_thread_pool_cond);
+
+    return ret;
+}
+
+/**
+*******************************************************************************
+*
+* @brief
+*  Worker thread function for processing encoding tasks.
+*
+* @par Description:
+*  Waits for available jobs and processes encoding tasks until signaled to
+*  terminate.
+*
+* @param[in] pv_proc
+*  Pointer to the process context.
+*
+* @returns  IH264_SUCCESS on completion.
+*
+*******************************************************************************
+*/
+static WORD32 ih264e_thread_worker(void *pv_proc)
+{
+    /* process ctxt */
+    process_ctxt_t *ps_proc = (process_ctxt_t *)pv_proc;
+
+    /* process ctxt */
+    codec_t *ps_codec = ps_proc->ps_codec;
+
+    /* thread pool ctxt */
+    thread_pool_t *ps_pool = &ps_codec->s_thread_pool;
+
+    while (1)
+    {
+        // Wait until a frame is ready or end of stream
+        ithread_mutex_lock(ps_pool->pv_thread_pool_mutex);
+        while (!ps_pool->i4_has_frame && !ps_pool->i4_end_of_stream)
+        {
+            ithread_cond_wait(ps_pool->pv_thread_pool_cond,
+                              ps_pool->pv_thread_pool_mutex);
+        }
+
+        if (ps_pool->i4_end_of_stream)
+        {
+            ithread_mutex_unlock(ps_pool->pv_thread_pool_mutex);
+            break;
+        }
+
+        /* incrementing active threads */
+        ps_pool->i4_working_threads++;
+        ithread_mutex_unlock(ps_pool->pv_thread_pool_mutex);
+
+        /* worker processes available jobs */
+        ih264e_process_thread(pv_proc);
+
+        /* decreasing active threads */
+        ithread_mutex_lock(ps_pool->pv_thread_pool_mutex);
+        ps_pool->i4_working_threads--;
+
+        /* Notify main thread if all workers are done */
+        if (ps_pool->i4_working_threads == 0 &&
+            ih264_get_job_count_in_list(ps_codec->pv_proc_jobq) == 0 &&
+            ih264_get_job_count_in_list(ps_codec->pv_entropy_jobq) == 0)
+        {
+            ps_pool->i4_has_frame = 0;
+            ithread_cond_signal(ps_pool->pv_thread_pool_cond);
+        }
+        ithread_mutex_unlock(ps_pool->pv_thread_pool_mutex);
+    }
+
+    return IH264_SUCCESS;
+}
+
+/**
+*******************************************************************************
+*
+* @brief
+*  Resets the thread pool state for the next encoding frame.
+*
+* @par Description:
+*  Resets the active thread count and signals worker threads to start
+*  processing a new frame.
+*
+* @param[in] ps_codec
+*  Pointer to the codec context structure.
+*
+* @returns  IH264_SUCCESS on success.
+*
+*******************************************************************************
+*/
+WORD32 ih264e_thread_pool_activate(codec_t *ps_codec)
+{
+    IH264_ERROR_T ret = IH264_SUCCESS;
+
+    /* thread pool ctxt */
+    thread_pool_t *ps_pool = &ps_codec->s_thread_pool;
+
+    if (ps_codec->i4_proc_thread_cnt == 0)
+    {
+        return ret;
+    }
+
+    /* reset working threads and new frame */
+    ithread_mutex_lock(ps_pool->pv_thread_pool_mutex);
+    ps_pool->i4_working_threads = 0;
+    ps_pool->i4_has_frame = 1;
+    ithread_cond_broadcast(ps_pool->pv_thread_pool_cond);
+    ithread_mutex_unlock(ps_pool->pv_thread_pool_mutex);
+
+    return ret;
+}
+
+/**
+*******************************************************************************
+*
+* @brief
+*  Synchronizes the thread pool by waiting for all tasks to complete.
+*
+* @par Description:
+*  Ensures that all worker threads complete their processing before
+*  proceeding to the next frame.
+*
+* @param[in] ps_codec
+*  Pointer to the codec context structure.
+*
+* @returns  IH264_SUCCESS on success.
+*
+*******************************************************************************
+*/
+WORD32 ih264e_thread_pool_sync(codec_t *ps_codec)
+{
+    IH264_ERROR_T ret = IH264_SUCCESS;
+
+    /* thread pool ctxt */
+    thread_pool_t *ps_pool = &ps_codec->s_thread_pool;
+
+    /* skip for single thread */
+    if (ps_codec->i4_proc_thread_cnt == 0)
+    {
+        return ret;
+    }
+
+    // Wait for workers to complete
+    ithread_mutex_lock(ps_pool->pv_thread_pool_mutex);
+    while (ps_pool->i4_has_frame == 1)
+    {
+        ithread_cond_wait(ps_pool->pv_thread_pool_cond,
+                          ps_pool->pv_thread_pool_mutex);
+    }
+    ithread_mutex_unlock(ps_pool->pv_thread_pool_mutex);
+
+    return ret;
+}
+#else
+
 /**
 ******************************************************************************
 *
@@ -149,6 +429,7 @@ void ih264e_join_threads(codec_t *ps_codec)
 
    ps_codec->i4_proc_thread_cnt = 0;
 }
+#endif /* KEEP_THREADS_ACTIVE */
 
 /**
 ******************************************************************************
@@ -586,6 +867,11 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
         {
             ps_codec->i4_gen_header = 1;
         }
+
+#ifdef KEEP_THREADS_ACTIVE /* initialize thread pool */
+        ih264e_thread_pool_init(ps_codec);
+#endif /* KEEP_THREADS_ACTIVE */
+
     }
 
     /* generate header and return when encoder is operated in header mode */
@@ -667,6 +953,16 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
                             ps_video_encode_op->s_ive_op.u4_error_code,
                             IV_FAIL);
 
+#ifdef KEEP_THREADS_ACTIVE
+        /* reset thread pool and prepare for new frame */
+        ih264e_thread_pool_activate(ps_codec);
+
+        /* main thread */
+        ih264e_process_thread(&ps_codec->as_process[0]);
+
+        /* sync all threads */
+        ih264e_thread_pool_sync(ps_codec);
+#else
         for (i = 0; i < num_thread_cnt; i++)
         {
             ret = ithread_create(ps_codec->apv_proc_thread_handle[i],
@@ -690,6 +986,7 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
 
         /* Join threads at the end of encoding a frame */
         ih264e_join_threads(ps_codec);
+#endif /* KEEP_THREADS_ACTIVE */
 
         ih264_list_reset(ps_codec->pv_proc_jobq);
 

--- a/encoder/ih264e_master.h
+++ b/encoder/ih264e_master.h
@@ -41,8 +41,23 @@
 /*****************************************************************************/
 /* Function Declarations                                                     */
 /*****************************************************************************/
+#ifdef KEEP_THREADS_ACTIVE
+
+WORD32 ih264e_thread_pool_init(codec_t *ps_codec);
+
+WORD32 ih264e_thread_pool_shutdown(codec_t *ps_codec);
+
+static WORD32 ih264e_thread_worker(void *pv_proc);
+
+WORD32 ih264e_thread_pool_activate(codec_t *ps_codec);
+
+WORD32 ih264e_thread_pool_sync(codec_t *ps_codec);
+
+#else
 
 void ih264e_join_threads(codec_t *ps_codec);
+
+#endif /* KEEP_THREADS_ACTIVE */
 
 void ih264e_compute_quality_stats(process_ctxt_t *ps_proc);
 

--- a/encoder/ih264e_structs.h
+++ b/encoder/ih264e_structs.h
@@ -1155,6 +1155,54 @@ typedef struct
 
 } entropy_ctxt_t;
 
+#ifdef KEEP_THREADS_ACTIVE
+/**
+ ******************************************************************************
+ *  @brief     The thread_pool_t structure manages a pool of worker threads,
+ *             providing synchronization mechanisms for job scheduling, codec
+ *             processing, and controlled execution flow.
+ ******************************************************************************
+ */
+typedef struct
+{
+    /**
+     * Array of worker thread handles
+     */
+    void *apv_threads[MAX_PROCESS_THREADS];
+
+    /**
+     * Mutex for synchronizing access to the thread pool
+     */
+    void *pv_thread_pool_mutex;
+
+    /**
+     * Condition variable for signaling worker threads
+     */
+    void *pv_thread_pool_cond;
+
+    /**
+     * Flag indicating whether the thread pool is initialized
+     */
+    WORD32 i4_init_done;
+
+    /**
+     * Flag indicating whether the thread pool should be terminated
+     */
+    WORD32 i4_end_of_stream;
+
+    /**
+     * Flag indicating the availability of a new frame for processing
+     */
+    WORD32 i4_has_frame;
+
+    /**
+     * Number of threads currently processing tasks
+     */
+    WORD32 i4_working_threads;
+
+} thread_pool_t;
+#endif /* KEEP_THREADS_ACTIVE */
+
 /**
 ******************************************************************************
 *  @brief      macro block info.
@@ -2414,6 +2462,13 @@ struct _codec_t
      */
      void *pv_out_buf_mgr_base;
 
+#ifdef KEEP_THREADS_ACTIVE
+    /**
+     * Thread pool
+     */
+    thread_pool_t s_thread_pool;
+#endif /* KEEP_THREADS_ACTIVE */
+
     /**
      * Buffer manager for output buffers
      */
@@ -2500,10 +2555,12 @@ struct _codec_t
      */
     process_ctxt_t as_process[MAX_PROCESS_CTXT];
 
+#ifndef KEEP_THREADS_ACTIVE
     /**
      * Thread handle for each of the processing threads
      */
     void *apv_proc_thread_handle[MAX_PROCESS_THREADS];
+#endif
 
     /**
      * Structure for global PSNR

--- a/encoder/libavcenc.cmake
+++ b/encoder/libavcenc.cmake
@@ -90,3 +90,7 @@ add_library(libavcenc STATIC ${LIBAVC_COMMON_SRCS} ${LIBAVC_COMMON_ASMS}
                              ${LIBAVCENC_SRCS} ${LIBAVCENC_ASMS})
 
 target_compile_definitions(libavcenc PRIVATE N_MB_ENABLE)
+
+if(KEEP_THREADS_ACTIVE)
+  target_compile_definitions(libavcenc PRIVATE KEEP_THREADS_ACTIVE)
+endif()


### PR DESCRIPTION
Currently avc encoder creates desired number of threads at the start of every frame and joins after frame is processed. This change modifies the thread creation part. Now the threads are created at the start of the sequence. Kept alive through out the sequence and joined at the end of the sequence. This helps in reduction of thread creation and deletion overhead.

This change does not effect the encoded bitstream. That is, encoded output with this change is same as encoded output without this change.

Bug:288998933
Test: avcenc -c enc.cfg