### PR TITLE
avcenc: Fix thread management and memory cleanup

### DIFF
--- a/encoder/ih264e_api.c
+++ b/encoder/ih264e_api.c
@@ -2857,6 +2857,14 @@ static WORD32 ih264e_init(codec_t *ps_codec)
     /* ctl mutex init */
     ithread_mutex_init(ps_codec->pv_ctl_mutex);
 
+#ifdef KEEP_THREADS_ACTIVE
+    /* thread pool mutex init */
+    ithread_mutex_init(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+
+    /* thread pool conditional init */
+    ithread_cond_init(ps_codec->s_thread_pool.pv_thread_pool_cond);
+#endif /* KEEP_THREADS_ACTIVE */
+
     /* Set encoder chroma format */
     ps_codec->e_codec_color_format =
                     (ps_cfg->e_inp_color_fmt == IV_YUV_420SP_VU) ?
@@ -5005,7 +5013,10 @@ static WORD32 ih264e_retrieve_memrec(iv_obj_t *ps_codec_obj,
     ih264_list_free(ps_codec->pv_proc_jobq);
     ithread_mutex_destroy(ps_codec->pv_ctl_mutex);
     ithread_mutex_destroy(ps_codec->pv_entropy_mutex);
-
+#ifdef KEEP_THREADS_ACTIVE
+    ithread_cond_destroy(ps_codec->s_thread_pool.pv_thread_pool_cond);
+    ithread_mutex_destroy(ps_codec->s_thread_pool.pv_thread_pool_mutex);
+#endif /* KEEP_THREADS_ACTIVE */
 
     ih264_buf_mgr_free((buf_mgr_t *)ps_codec->pv_mv_buf_mgr);
     ih264_buf_mgr_free((buf_mgr_t *)ps_codec->pv_ref_buf_mgr);

--- a/encoder/ih264e_encode.c
+++ b/encoder/ih264e_encode.c
@@ -1276,5 +1276,12 @@ WORD32 ih264e_encode(iv_obj_t *ps_codec_obj, void *pv_api_ip, void *pv_api_op)
 
     ps_video_encode_op->s_ive_op.s_out_buf = s_out_buf.s_bits_buf;
 
+#ifdef KEEP_THREADS_ACTIVE
+    if(ps_video_encode_op->s_ive_op.u4_is_last)
+    {
+        ih264e_thread_pool_shutdown(ps_codec);
+    }
+#endif
+
     return IV_SUCCESS;
 }

--- a/fuzzer/avc_enc_fuzzer.cpp
+++ b/fuzzer/avc_enc_fuzzer.cpp
@@ -136,6 +136,7 @@ class Codec {
     void setSeiCcvParams();
     void setSeiSiiParams();
     void logVersion();
+    void retrieveMemRecords();
     bool mHalfPelEnable = 1;
     bool mQPelEnable = 1;
     bool mIntra4x4 = 0;
@@ -878,6 +879,21 @@ void Codec::logVersion() {
     return;
 }
 
+void Codec::retrieveMemRecords()
+{
+    iv_retrieve_mem_rec_ip_t s_retrieve_ip{};
+    iv_retrieve_mem_rec_op_t s_retrieve_op{};
+
+    s_retrieve_ip.e_cmd = IV_CMD_RETRIEVE_MEMREC;
+    s_retrieve_ip.u4_size = sizeof(iv_retrieve_mem_rec_ip_t);
+    s_retrieve_ip.ps_mem_rec = mMemRecords;
+
+    s_retrieve_op.u4_size = sizeof(iv_retrieve_mem_rec_op_t);
+
+    ive_api_function(mCodecCtx, &s_retrieve_ip, &s_retrieve_op);
+    return;
+}
+
 void Codec::encodeFrames(const uint8_t *data, size_t size) {
     size_t frameSize = (mIvVideoColorFormat == IV_YUV_422ILE) ? (mWidth * mHeight * 2)
                                                               : ((mWidth * mHeight * 3) / 2);
@@ -982,6 +998,7 @@ void Codec::encodeFrames(const uint8_t *data, size_t size) {
         ++numEncodeCalls;
         free(outputBuffer);
     }
+    retrieveMemRecords();
     for (const auto &buffer : inBuffers) {
         free(std::get<0>(buffer));
         if (std::get<1>(buffer)) {


### PR DESCRIPTION
Adds proper thread pool shutdown on the last frame when KEEP_THREADS_ACTIVE is defined.
Moves mutex and conditional variable initialization/destruction to appropriate locations out of thread pool init and shutdown.
Calls retrieve_memrec before deinitialization in the fuzzer.

Test:  avcenc -c enc.cfg