### PR TITLE
avcenc: Replacing KEEP_THREADS_ACTIVE with runtime check

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -83,7 +83,6 @@ cc_defaults {
         "-Wall",
         "-Werror",
         "-Wno-error=constant-conversion",
-        "-UKEEP_THREADS_ACTIVE",
     ],
     arch: {
         arm: {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ set(AVC_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 option(ENABLE_MVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_SVC "Enables svcenc and svcdec builds" OFF)
 option(ENABLE_TESTS "Enables gtest based unit tests" OFF)
-option(KEEP_THREADS_ACTIVE "Enable KEEP THREADS ACTIVE" OFF)
 
 if("${AVC_ROOT}" STREQUAL "${AVC_CONFIG_DIR}")
   message(

--- a/common/ih264_list.c
+++ b/common/ih264_list.c
@@ -558,7 +558,6 @@ IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf, WORD32 blocking)
     return ret;
 }
 
-#ifdef KEEP_THREADS_ACTIVE
 /**
 *******************************************************************************
 *
@@ -585,4 +584,3 @@ WORD32 ih264_get_job_count_in_list(list_t *ps_list)
     RETURN_IF((ih264_list_unlock(ps_list) != IH264_SUCCESS), 0);
     return jobs;
 }
-#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ih264_list.h
+++ b/common/ih264_list.h
@@ -100,10 +100,6 @@ IH264_ERROR_T ih264_list_queue(list_t *ps_list, void *pv_buf, WORD32 blocking);
 IH264_ERROR_T ih264_list_dequeue(list_t *ps_list, void *pv_buf,
                                  WORD32 blocking);
 
-#ifdef KEEP_THREADS_ACTIVE
-
 WORD32 ih264_get_job_count_in_list(list_t *ps_list);
-
-#endif /* KEEP_THREADS_ACTIVE */
 
 #endif /* _IH264_LIST_H_ */

--- a/common/ithread.c
+++ b/common/ithread.c
@@ -235,7 +235,6 @@ WORD32 ithread_cond_signal(void *cond)
     return pthread_cond_signal((pthread_cond_t *)cond);
 }
 
-#ifdef KEEP_THREADS_ACTIVE
 UWORD32 ithread_get_cond_size(void)
 {
     return sizeof(pthread_cond_t);
@@ -245,4 +244,3 @@ WORD32  ithread_cond_broadcast(void *cond)
 {
     return pthread_cond_broadcast((pthread_cond_t *)cond);
 }
-#endif /* KEEP_THREADS_ACTIVE */

--- a/common/ithread.h
+++ b/common/ithread.h
@@ -95,12 +95,8 @@ WORD32  ithread_cond_wait(void *cond, void *mutex);
 
 WORD32  ithread_cond_signal(void *cond);
 
-#ifdef KEEP_THREADS_ACTIVE
-
 UWORD32 ithread_get_cond_size(void);
 
 WORD32  ithread_cond_broadcast(void *cond);
-
-#endif /* KEEP_THREADS_ACTIVE */
 
 #endif /* _ITHREAD_H_ */

--- a/encoder/ih264e_defs.h
+++ b/encoder/ih264e_defs.h
@@ -469,17 +469,10 @@ enum
      */
     MEM_REC_SLICE_MAP,
 
-#ifdef KEEP_THREADS_ACTIVE
-    /**
-     * Holds thread pool
-     */
-    MEM_REC_THREAD_POOL,
-#else
     /**
      * Holds thread handles
      */
     MEM_REC_THREAD_HANDLE,
-#endif /* KEEP_THREADS_ACTIVE */
 
     /**
      * Holds control call mutex

--- a/encoder/ih264e_master.h
+++ b/encoder/ih264e_master.h
@@ -41,7 +41,6 @@
 /*****************************************************************************/
 /* Function Declarations                                                     */
 /*****************************************************************************/
-#ifdef KEEP_THREADS_ACTIVE
 
 WORD32 ih264e_thread_pool_init(codec_t *ps_codec);
 
@@ -53,11 +52,7 @@ WORD32 ih264e_thread_pool_activate(codec_t *ps_codec);
 
 WORD32 ih264e_thread_pool_sync(codec_t *ps_codec);
 
-#else
-
 void ih264e_join_threads(codec_t *ps_codec);
-
-#endif /* KEEP_THREADS_ACTIVE */
 
 void ih264e_compute_quality_stats(process_ctxt_t *ps_proc);
 

--- a/encoder/ih264e_structs.h
+++ b/encoder/ih264e_structs.h
@@ -582,6 +582,9 @@ typedef struct
     /** SEI structure                                                         */
     sei_params_t                                s_sei;
 
+    /** Enabling thread pool                                                  */
+    UWORD32                                     u4_keep_threads_active;
+
 }cfg_params_t;
 
 
@@ -1155,7 +1158,6 @@ typedef struct
 
 } entropy_ctxt_t;
 
-#ifdef KEEP_THREADS_ACTIVE
 /**
  ******************************************************************************
  *  @brief     The thread_pool_t structure manages a pool of worker threads,
@@ -1201,7 +1203,6 @@ typedef struct
     WORD32 i4_working_threads;
 
 } thread_pool_t;
-#endif /* KEEP_THREADS_ACTIVE */
 
 /**
 ******************************************************************************
@@ -2462,12 +2463,10 @@ struct _codec_t
      */
      void *pv_out_buf_mgr_base;
 
-#ifdef KEEP_THREADS_ACTIVE
     /**
      * Thread pool
      */
     thread_pool_t s_thread_pool;
-#endif /* KEEP_THREADS_ACTIVE */
 
     /**
      * Buffer manager for output buffers
@@ -2555,12 +2554,10 @@ struct _codec_t
      */
     process_ctxt_t as_process[MAX_PROCESS_CTXT];
 
-#ifndef KEEP_THREADS_ACTIVE
     /**
      * Thread handle for each of the processing threads
      */
     void *apv_proc_thread_handle[MAX_PROCESS_THREADS];
-#endif
 
     /**
      * Structure for global PSNR

--- a/encoder/iv2.h
+++ b/encoder/iv2.h
@@ -335,6 +335,9 @@ typedef struct {
     /** Maximum search range to be used in Y direction                      */
     UWORD32                                     u4_max_srch_rng_y;
 
+    /** Enabling thread pool                                                */
+    UWORD32                                     u4_keep_threads_active;
+
 }iv_fill_mem_rec_ip_t;
 
 

--- a/encoder/ive2.h
+++ b/encoder/ive2.h
@@ -325,11 +325,14 @@ typedef struct
     /** Slice parameter                                                     */
     UWORD32                                 u4_slice_param;
 
-    /** Processor architecture                                          */
-    IV_ARCH_T                                   e_arch;
+    /** Processor architecture                                              */
+    IV_ARCH_T                               e_arch;
 
-    /** SOC details                                                     */
-    IV_SOC_T                                    e_soc;
+    /** SOC details                                                         */
+    IV_SOC_T                                e_soc;
+
+    /** Enabling thread pool                                                */
+    UWORD32                                 u4_keep_threads_active;
 
 
 }ive_init_ip_t;

--- a/encoder/libavcenc.cmake
+++ b/encoder/libavcenc.cmake
@@ -90,7 +90,3 @@ add_library(libavcenc STATIC ${LIBAVC_COMMON_SRCS} ${LIBAVC_COMMON_ASMS}
                              ${LIBAVCENC_SRCS} ${LIBAVCENC_ASMS})
 
 target_compile_definitions(libavcenc PRIVATE N_MB_ENABLE)
-
-if(KEEP_THREADS_ACTIVE)
-  target_compile_definitions(libavcenc PRIVATE KEEP_THREADS_ACTIVE)
-endif()

--- a/examples/avcenc/app.h
+++ b/examples/avcenc/app.h
@@ -384,6 +384,8 @@ typedef struct
     ih264e_ctl_set_sei_ave_params_ip_t s_sei_ave_params;
     ih264e_ctl_set_sei_sii_params_ip_t s_sei_sii_params;
 
+    UWORD32 u4_keep_threads_active;
+
 } app_ctxt_t;
 
 

--- a/examples/avcenc/enc.cfg
+++ b/examples/avcenc/enc.cfg
@@ -44,4 +44,5 @@
 --bframes 0
 --adaptive_intra_refresh 0
 --air_refresh_period 30
+--keep_threads_active 0
 

--- a/examples/avcenc/main.c
+++ b/examples/avcenc/main.c
@@ -134,6 +134,7 @@ typedef enum
     MB_INFO_TYPE,
     PIC_INFO_FILE,
     PIC_INFO_TYPE,
+    KEEP_THREADS_ACTIVE,
 } ARGUMENT_T;
 
 /*****************************************************************************/
@@ -234,6 +235,7 @@ static const argument_t argument_mapping[] =
         { "--", "--mb_info_type", MB_INFO_TYPE, "MB info type\n"},
         { "--", "--pic_info_file", PIC_INFO_FILE, "Pic info file\n"},
         { "--", "--pic_info_type", PIC_INFO_TYPE, "Pic info type\n"},
+        { "--", "--keep_threads_active", KEEP_THREADS_ACTIVE, "keep threads active\n"},
 };
 
 
@@ -775,6 +777,10 @@ void parse_argument(app_ctxt_t *ps_app_ctxt, CHAR *argument, CHAR *value)
 
         case INTRA_4x4_ENABLE:
             sscanf(value, "%d", &ps_app_ctxt->u4_enable_intra_4x4);
+            break;
+
+        case KEEP_THREADS_ACTIVE:
+            sscanf(value, "%d", &ps_app_ctxt->u4_keep_threads_active);
             break;
 
         case INVALID:
@@ -2728,6 +2734,7 @@ int main(int argc, char *argv[])
         s_fill_mem_rec_ip.s_ive_ip.e_color_format = DEFAULT_INP_COLOR_FMT;
         s_fill_mem_rec_ip.s_ive_ip.u4_max_srch_rng_x = DEFAULT_MAX_SRCH_RANGE_X;
         s_fill_mem_rec_ip.s_ive_ip.u4_max_srch_rng_y = DEFAULT_MAX_SRCH_RANGE_Y;
+        s_fill_mem_rec_ip.s_ive_ip.u4_keep_threads_active = s_app_ctxt.u4_keep_threads_active;
 
         s_fill_mem_rec_op.s_ive_op.u4_size = sizeof(ih264e_fill_mem_rec_op_t);
 
@@ -2810,6 +2817,7 @@ int main(int argc, char *argv[])
         s_init_ip.s_ive_ip.u4_slice_param = s_app_ctxt.u4_slice_param;
         s_init_ip.s_ive_ip.e_arch = s_app_ctxt.e_arch;
         s_init_ip.s_ive_ip.e_soc = s_app_ctxt.e_soc;
+        s_init_ip.s_ive_ip.u4_keep_threads_active = s_app_ctxt.u4_keep_threads_active;
 
         s_init_op.s_ive_op.u4_size = sizeof(ih264e_init_op_t);
 

--- a/fuzzer/avc_enc_fuzzer.cpp
+++ b/fuzzer/avc_enc_fuzzer.cpp
@@ -175,6 +175,7 @@ class Codec {
     uint32_t mForceIdrInterval = 0;          // in number of frames
     uint32_t mDynamicBitRateInterval = 0;    // in number of frames
     uint32_t mDynamicFrameRateInterval = 0;  // in number of frames
+    uint32_t mKeepThreadsActive;
     uint64_t mBitrate = 6000000;
     float mFrameRate = 30;
     iv_obj_t *mCodecCtx = nullptr;
@@ -234,6 +235,7 @@ bool Codec::initEncoder(const uint8_t **pdata, size_t *psize) {
     mForceIdrInterval = data[IDX_FORCE_IDR_INTERVAL] & 0x07;
     mDynamicBitRateInterval = data[IDX_DYNAMIC_BITRATE_INTERVAL] & 0x07;
     mDynamicFrameRateInterval = data[IDX_DYNAMIC_FRAME_RATE_INTERVAL] & 0x07;
+    mKeepThreadsActive = 0;
 
     /* Getting Number of MemRecords */
     iv_num_mem_rec_ip_t sNumMemRecIp{};
@@ -280,6 +282,7 @@ bool Codec::initEncoder(const uint8_t **pdata, size_t *psize) {
     sFillMemRecIp.u4_max_reorder_cnt = 0;
     sFillMemRecIp.u4_max_srch_rng_x = 256;
     sFillMemRecIp.u4_max_srch_rng_y = 256;
+    sFillMemRecIp.u4_keep_threads_active = mKeepThreadsActive;
 
     if (IV_SUCCESS != ive_api_function(nullptr, &sFillMemRecIp, &sFillMemRecOp)) {
         return false;
@@ -327,6 +330,7 @@ bool Codec::initEncoder(const uint8_t **pdata, size_t *psize) {
     sInitIp.u4_slice_param = mSliceParam;
     sInitIp.e_arch = mArch;
     sInitIp.e_soc = SOC_GENERIC;
+    sInitIp.u4_keep_threads_active = mKeepThreadsActive;
 
     if (IV_SUCCESS != ive_api_function(mCodecCtx, &sInitIp, &sInitOp)) {
         return false;


### PR DESCRIPTION
Test: avcenc -c enc.cfg
Change-Id: If6c8c29d2b5b1322796b8b25dc74231d13b61243