### PR TITLE
avcenc: Enabling keep_threads_active in cfg and avc_enc_fuzzer

### DIFF
--- a/examples/avcenc/enc.cfg
+++ b/examples/avcenc/enc.cfg
@@ -44,5 +44,5 @@
 --bframes 0
 --adaptive_intra_refresh 0
 --air_refresh_period 30
---keep_threads_active 0
+--keep_threads_active 1
 

--- a/fuzzer/avc_enc_fuzzer.cpp
+++ b/fuzzer/avc_enc_fuzzer.cpp
@@ -235,7 +235,7 @@ bool Codec::initEncoder(const uint8_t **pdata, size_t *psize) {
     mForceIdrInterval = data[IDX_FORCE_IDR_INTERVAL] & 0x07;
     mDynamicBitRateInterval = data[IDX_DYNAMIC_BITRATE_INTERVAL] & 0x07;
     mDynamicFrameRateInterval = data[IDX_DYNAMIC_FRAME_RATE_INTERVAL] & 0x07;
-    mKeepThreadsActive = 0;
+    mKeepThreadsActive = 1;
 
     /* Getting Number of MemRecords */
     iv_num_mem_rec_ip_t sNumMemRecIp{};


### PR DESCRIPTION
Test: avcenc -c enc.cfg
Change-Id: I45b32621aa3d64b569e5ac6b7f23405aa1711c82