### PR TITLE
Redefine examples test modules as cc_binary

### DIFF
--- a/examples/Android.bp
+++ b/examples/Android.bp
@@ -46,7 +46,7 @@ cc_defaults {
     static_libs: ["libavcenc"],
 }
 
-cc_test {
+cc_binary {
     name: "avcdec",
     defaults: ["avcdec_defaults"],
     local_include_dirs: [
@@ -56,7 +56,7 @@ cc_test {
     static_libs: ["libavcdec"],
 }
 
-cc_test {
+cc_binary {
     name: "mvcdec",
     defaults: ["avcdec_defaults"],
     local_include_dirs: [
@@ -68,7 +68,7 @@ cc_test {
     ],
 }
 
-cc_test {
+cc_binary {
     name: "avcenc",
     defaults: ["avcenc_defaults"],
 
@@ -81,7 +81,7 @@ cc_test {
     ],
 }
 
-cc_test {
+cc_binary {
     name: "svcenc",
     defaults: ["avcenc_defaults"],
 
@@ -102,7 +102,7 @@ cc_test {
     ],
 }
 
-cc_test {
+cc_binary {
     name: "svcdec",
     defaults: ["avcdec_defaults"],
 


### PR DESCRIPTION
This change redefines the `cc_test` modules within the examples directory as `cc_binary` modules.

Previously, these `cc_test` modules were effectively acting as wrappers around executable binaries, solely for the purpose of generating test executables. This approach did not allow for the direct installation of these executables on devices.

Changing these modules to `cc_binary` allows the resulting executables are produced as standalone binaries, enabling their deployment and execution on test devices.

Bug: 414657128
Change-Id: I9caef8a5cf29c7d77b8bcd535f047a640c52285c