### PR TITLE
avcenc: cleanup for thread pool memory handling

### DIFF
--- a/encoder/ih264e_encode.c
+++ b/encoder/ih264e_encode.c
@@ -152,7 +152,7 @@ WORD32 ih264e_thread_pool_init(codec_t *ps_codec)
 
     for (i = 1; i < ps_codec->s_cfg.u4_num_cores; i++)
     {
-        ret = ithread_create(ps_pool->apv_threads[i], NULL, ih264e_thread_worker,
+        ret = ithread_create(ps_codec->apv_proc_thread_handle[i], NULL, ih264e_thread_worker,
                              (void *) &ps_codec->as_process[i]);
         if (ret != 0)
         {
@@ -207,7 +207,7 @@ WORD32 ih264e_thread_pool_shutdown(codec_t *ps_codec)
     {
         if (ps_codec->ai4_process_thread_created[i])
         {
-            if (ithread_join(ps_pool->apv_threads[i], NULL) != 0)
+            if (ithread_join(ps_codec->apv_proc_thread_handle[i], NULL) != 0)
             {
                 ret = IV_FAIL;
             }

--- a/encoder/ih264e_structs.h
+++ b/encoder/ih264e_structs.h
@@ -1168,11 +1168,6 @@ typedef struct
 typedef struct
 {
     /**
-     * Array of worker thread handles
-     */
-    void *apv_threads[MAX_PROCESS_THREADS];
-
-    /**
      * Mutex for synchronizing access to the thread pool
      */
     void *pv_thread_pool_mutex;


### PR DESCRIPTION
Test: avcenc -c enc.cfg

Change-Id: I5f5cf7f705d389f6938fc641daa558bedfbc573c