### PR TITLE
libavc: Add BTI and PAC support in libavc

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -290,7 +290,6 @@ cc_library_static {
     name: "libavcdec",
     defaults: [
         "libavc_dec_defaults",
-        "no_bti",
     ],
 
     export_include_dirs: [

--- a/common/armv8/ih264_deblk_chroma_av8.s
+++ b/common/armv8/ih264_deblk_chroma_av8.s
@@ -38,9 +38,8 @@
 ///*****************************************************************************/
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 ///**
 //*******************************************************************************
@@ -82,7 +81,7 @@
 
     .global ih264_deblk_chroma_horz_bs4_av8
 
-ih264_deblk_chroma_horz_bs4_av8:
+ENTRY ih264_deblk_chroma_horz_bs4_av8
 
     // STMFD sp!,{x4-x6,x14}            //
     push_v_regs
@@ -138,6 +137,7 @@ ih264_deblk_chroma_horz_bs4_av8:
     // LDMFD sp!,{x4-x6,pc}                //
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -182,7 +182,7 @@ ih264_deblk_chroma_horz_bs4_av8:
 
     .global ih264_deblk_chroma_vert_bs4_av8
 
-ih264_deblk_chroma_vert_bs4_av8:
+ENTRY ih264_deblk_chroma_vert_bs4_av8
 
     // STMFD sp!,{x4,x5,x12,x14}
     push_v_regs
@@ -276,6 +276,7 @@ ih264_deblk_chroma_vert_bs4_av8:
     // LDMFD sp!,{x4,x5,x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -329,7 +330,7 @@ ih264_deblk_chroma_vert_bs4_av8:
 
     .global ih264_deblk_chroma_horz_bslt4_av8
 
-ih264_deblk_chroma_horz_bslt4_av8:
+ENTRY ih264_deblk_chroma_horz_bslt4_av8
 
     // STMFD sp!,{x4-x9,x14}        //
     push_v_regs
@@ -410,6 +411,7 @@ ih264_deblk_chroma_horz_bslt4_av8:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -464,7 +466,7 @@ ih264_deblk_chroma_horz_bslt4_av8:
 
     .global ih264_deblk_chroma_vert_bslt4_av8
 
-ih264_deblk_chroma_vert_bslt4_av8:
+ENTRY ih264_deblk_chroma_vert_bslt4_av8
 
     // STMFD sp!,{x4-x7,x10-x12,x14}
     push_v_regs
@@ -582,6 +584,7 @@ ih264_deblk_chroma_vert_bslt4_av8:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_deblk_luma_av8.s
+++ b/common/armv8/ih264_deblk_luma_av8.s
@@ -40,9 +40,8 @@
 ///*****************************************************************************/
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
@@ -86,7 +85,7 @@
 
     .global ih264_deblk_luma_horz_bslt4_av8
 
-ih264_deblk_luma_horz_bslt4_av8:
+ENTRY ih264_deblk_luma_horz_bslt4_av8
 
     // STMFD sp!,{x4-x7,x14}
     push_v_regs
@@ -197,6 +196,7 @@ ih264_deblk_luma_horz_bslt4_av8:
     // LDMFD sp!,{x4-x7,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -235,7 +235,7 @@ ih264_deblk_luma_horz_bslt4_av8:
 
     .global ih264_deblk_luma_horz_bs4_av8
 
-ih264_deblk_luma_horz_bs4_av8:
+ENTRY ih264_deblk_luma_horz_bs4_av8
 
     // Back up necessary registers on stack
     // STMFD sp!,{x12,x14}
@@ -385,6 +385,7 @@ ih264_deblk_luma_horz_bs4_av8:
     // LDMFD sp!,{x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -429,7 +430,7 @@ ih264_deblk_luma_horz_bs4_av8:
 
     .global ih264_deblk_luma_vert_bslt4_av8
 
-ih264_deblk_luma_vert_bslt4_av8:
+ENTRY ih264_deblk_luma_vert_bslt4_av8
 
     // STMFD sp!,{x12,x14}
     push_v_regs
@@ -728,6 +729,7 @@ ih264_deblk_luma_vert_bslt4_av8:
     // LDMFD sp!,{x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -766,7 +768,7 @@ ih264_deblk_luma_vert_bslt4_av8:
 
     .global ih264_deblk_luma_vert_bs4_av8
 
-ih264_deblk_luma_vert_bs4_av8:
+ENTRY ih264_deblk_luma_vert_bs4_av8
 
     // STMFD sp!,{x12,x14}
     push_v_regs
@@ -1082,6 +1084,7 @@ ih264_deblk_luma_vert_bs4_av8:
     // LDMFD sp!,{x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_default_weighted_pred_av8.s
+++ b/common/armv8/ih264_default_weighted_pred_av8.s
@@ -101,15 +101,14 @@
 //    w6      => ht
 //    w7      => wd
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_default_weighted_pred_luma_av8
 
-ih264_default_weighted_pred_luma_av8:
+ENTRY ih264_default_weighted_pred_luma_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -213,6 +212,7 @@ end_loops:
     // LDMFD sp!,{x4-x7,x15}                      //Reload the registers from sp
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -285,7 +285,7 @@ end_loops:
 
     .global ih264_default_weighted_pred_chroma_av8
 
-ih264_default_weighted_pred_chroma_av8:
+ENTRY ih264_default_weighted_pred_chroma_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -352,6 +352,7 @@ loop_8_uv:                              //each iteration processes four rows
 end_loops_uv:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_ihadamard_scaling_av8.s
+++ b/common/armv8/ih264_ihadamard_scaling_av8.s
@@ -88,10 +88,9 @@
 //x4=>   u4_qp_div_6
 
 .text
-.p2align 2
 
     .global ih264_ihadamard_scaling_4x4_av8
-ih264_ihadamard_scaling_4x4_av8:
+ENTRY ih264_ihadamard_scaling_4x4_av8
 
 //only one shift is done in horizontal inverse because,
 //if u4_qp_div_6 is lesser than 4 then shift value will be neagative and do negative left shift, in this case rnd_factor has value
@@ -159,6 +158,7 @@ ih264_ihadamard_scaling_4x4_av8:
     st1       {v0.4h-v3.4h}, [x1]       //store the result
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -202,7 +202,7 @@ ih264_ihadamard_scaling_4x4_av8:
 //                                  UWORD32 u4_qp_div_6,
 
     .global ih264_ihadamard_scaling_2x2_uv_av8
-ih264_ihadamard_scaling_2x2_uv_av8:
+ENTRY ih264_ihadamard_scaling_2x2_uv_av8
 
 //Registers used
 //   x0 : *pi2_src
@@ -244,6 +244,7 @@ ih264_ihadamard_scaling_2x2_uv_av8:
 
     st2       {v0.4s-v1.4s}, [x1]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_chroma_av8.s
+++ b/common/armv8/ih264_inter_pred_chroma_av8.s
@@ -105,15 +105,14 @@
 //    w6 =>  height
 //    w7 =>  width
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_chroma_av8
 
-ih264_inter_pred_chroma_av8:
+ENTRY ih264_inter_pred_chroma_av8
 
 
 
@@ -393,6 +392,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_filters_luma_horz_av8.s
+++ b/common/armv8/ih264_inter_pred_filters_luma_horz_av8.s
@@ -94,16 +94,15 @@
 //    w4 =>  ht
 //    w5 =>  wd
 
-.text
-.p2align 2
 
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_horz_av8
 
-ih264_inter_pred_luma_horz_av8:
+ENTRY ih264_inter_pred_luma_horz_av8
 
 
 
@@ -528,6 +527,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_filters_luma_vert_av8.s
+++ b/common/armv8/ih264_inter_pred_filters_luma_vert_av8.s
@@ -94,16 +94,15 @@
 //    w4 =>  ht
 //    w5 =>  wd
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
 
     .global ih264_inter_pred_luma_vert_av8
 
-ih264_inter_pred_luma_vert_av8:
+ENTRY ih264_inter_pred_luma_vert_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -450,6 +449,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_copy_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_copy_av8.s
@@ -70,15 +70,14 @@
 //    w4 =>  ht
 //    w5 =>  wd
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_copy_av8
 
-ih264_inter_pred_luma_copy_av8:
+ENTRY ih264_inter_pred_luma_copy_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -128,6 +127,7 @@ end_loops:
     // LDMFD sp!,{x4-x12,x15}                  //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -161,6 +161,7 @@ end_inner_loop_wd_8:
     // LDMFD sp!,{x4-x12,x15}                  //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 core_loop_wd_16:
@@ -193,6 +194,7 @@ end_inner_loop_wd_16:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -238,7 +240,7 @@ end_inner_loop_wd_16:
 // No need for pushing  arm and neon registers
 
     .global ih264_interleave_copy_av8
-ih264_interleave_copy_av8:
+ENTRY ih264_interleave_copy_av8
     push_v_regs
     sxtw      x2, w2
     sxtw      x3, w3
@@ -268,6 +270,7 @@ ih264_interleave_copy_av8:
     st1       {v20.d}[1], [x0], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_horz_hpel_vert_hpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_horz_hpel_vert_hpel_av8.s
@@ -58,15 +58,14 @@
 //    w5 =>  wd
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_horz_hpel_vert_hpel_av8
 
-ih264_inter_pred_luma_horz_hpel_vert_hpel_av8:
+ENTRY ih264_inter_pred_luma_horz_hpel_vert_hpel_av8
 
     //store register values to stack
     push_v_regs
@@ -818,6 +817,7 @@ end_func:
     //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_horz_hpel_vert_qpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_horz_hpel_vert_qpel_av8.s
@@ -112,15 +112,14 @@
 //    x6 => *pu1_tmp
 //    w7 =>  dydx
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_horz_hpel_vert_qpel_av8
 
-ih264_inter_pred_luma_horz_hpel_vert_qpel_av8:
+ENTRY ih264_inter_pred_luma_horz_hpel_vert_qpel_av8
 
 
     // store register values to stack
@@ -1119,6 +1118,7 @@ end_func:
     //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_horz_qpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_horz_qpel_av8.s
@@ -100,16 +100,15 @@
 //    w5 =>  wd
 //    w7 =>  dydx
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
 
     .global ih264_inter_pred_luma_horz_qpel_av8
 
-ih264_inter_pred_luma_horz_qpel_av8:
+ENTRY ih264_inter_pred_luma_horz_qpel_av8
 
 
     push_v_regs
@@ -595,6 +594,7 @@ end_func:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_horz_qpel_vert_hpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_horz_qpel_vert_hpel_av8.s
@@ -112,15 +112,14 @@
 //    x6 => *pu1_tmp
 //    w7 =>  dydx
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_horz_qpel_vert_hpel_av8
 
-ih264_inter_pred_luma_horz_qpel_vert_hpel_av8:
+ENTRY ih264_inter_pred_luma_horz_qpel_vert_hpel_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -908,6 +907,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_horz_qpel_vert_qpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_horz_qpel_vert_qpel_av8.s
@@ -110,15 +110,14 @@
 //    w5 =>  wd
 //    w7 =>  dydx
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_horz_qpel_vert_qpel_av8
 
-ih264_inter_pred_luma_horz_qpel_vert_qpel_av8:
+ENTRY ih264_inter_pred_luma_horz_qpel_vert_qpel_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -956,6 +955,7 @@ loop_4_start:
 end_func:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_inter_pred_luma_vert_qpel_av8.s
+++ b/common/armv8/ih264_inter_pred_luma_vert_qpel_av8.s
@@ -100,15 +100,14 @@
 //    w5 =>  wd
 //    w7 =>  dydx
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_inter_pred_luma_vert_qpel_av8
 
-ih264_inter_pred_luma_vert_qpel_av8:
+ENTRY ih264_inter_pred_luma_vert_qpel_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -509,6 +508,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_intra_pred_chroma_av8.s
+++ b/common/armv8/ih264_intra_pred_chroma_av8.s
@@ -50,9 +50,8 @@
 //
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 .extern ih264_gai1_intrapred_chroma_plane_coeffs1
 .extern ih264_gai1_intrapred_chroma_plane_coeffs2
@@ -108,7 +107,7 @@
 
     .global ih264_intra_pred_chroma_8x8_mode_dc_av8
 
-ih264_intra_pred_chroma_8x8_mode_dc_av8:
+ENTRY ih264_intra_pred_chroma_8x8_mode_dc_av8
 
 
     push_v_regs
@@ -202,6 +201,7 @@ end_func:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -259,7 +259,7 @@ end_func:
 
     .global ih264_intra_pred_chroma_8x8_mode_horz_av8
 
-ih264_intra_pred_chroma_8x8_mode_horz_av8:
+ENTRY ih264_intra_pred_chroma_8x8_mode_horz_av8
 
 
 
@@ -286,6 +286,7 @@ ih264_intra_pred_chroma_8x8_mode_horz_av8:
 
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -341,7 +342,7 @@ ih264_intra_pred_chroma_8x8_mode_horz_av8:
 
     .global ih264_intra_pred_chroma_8x8_mode_vert_av8
 
-ih264_intra_pred_chroma_8x8_mode_vert_av8:
+ENTRY ih264_intra_pred_chroma_8x8_mode_vert_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -359,6 +360,7 @@ ih264_intra_pred_chroma_8x8_mode_vert_av8:
     st1       {v0.8b, v1.8b}, [x1], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -413,7 +415,7 @@ ih264_intra_pred_chroma_8x8_mode_vert_av8:
 //    w4 =>  ui_neighboravailability
 
     .global ih264_intra_pred_chroma_8x8_mode_plane_av8
-ih264_intra_pred_chroma_8x8_mode_plane_av8:
+ENTRY ih264_intra_pred_chroma_8x8_mode_plane_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -568,6 +570,7 @@ end_func_plane:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_intra_pred_luma_16x16_av8.s
+++ b/common/armv8/ih264_intra_pred_luma_16x16_av8.s
@@ -50,9 +50,8 @@
 //
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 .extern ih264_gai1_intrapred_luma_plane_coeffs
 
 
@@ -105,7 +104,7 @@
 
     .global ih264_intra_pred_luma_16x16_mode_vert_av8
 
-ih264_intra_pred_luma_16x16_mode_vert_av8:
+ENTRY ih264_intra_pred_luma_16x16_mode_vert_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -132,6 +131,7 @@ ih264_intra_pred_luma_16x16_mode_vert_av8:
     st1       {v0.8b, v1.8b}, [x1], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -188,7 +188,7 @@ ih264_intra_pred_luma_16x16_mode_vert_av8:
 
     .global ih264_intra_pred_luma_16x16_mode_horz_av8
 
-ih264_intra_pred_luma_16x16_mode_horz_av8:
+ENTRY ih264_intra_pred_luma_16x16_mode_horz_av8
 
 
 
@@ -233,6 +233,7 @@ ih264_intra_pred_luma_16x16_mode_horz_av8:
     st1       {v25.16b}, [x1], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -291,7 +292,7 @@ ih264_intra_pred_luma_16x16_mode_horz_av8:
 
     .global ih264_intra_pred_luma_16x16_mode_dc_av8
 
-ih264_intra_pred_luma_16x16_mode_dc_av8:
+ENTRY ih264_intra_pred_luma_16x16_mode_dc_av8
 
 
 
@@ -363,6 +364,7 @@ end_func:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -418,7 +420,7 @@ end_func:
 //    w4 =>  ui_neighboravailability
 
     .global ih264_intra_pred_luma_16x16_mode_plane_av8
-ih264_intra_pred_luma_16x16_mode_plane_av8:
+ENTRY ih264_intra_pred_luma_16x16_mode_plane_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -588,5 +590,6 @@ end_func_plane:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 

--- a/common/armv8/ih264_intra_pred_luma_4x4_av8.s
+++ b/common/armv8/ih264_intra_pred_luma_4x4_av8.s
@@ -54,9 +54,8 @@
 ///**
 //
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
@@ -108,7 +107,7 @@
 
     .global ih264_intra_pred_luma_4x4_mode_vert_av8
 
-ih264_intra_pred_luma_4x4_mode_vert_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_vert_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -122,6 +121,7 @@ ih264_intra_pred_luma_4x4_mode_vert_av8:
     st1       {v0.s}[0], [x1], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -180,7 +180,7 @@ ih264_intra_pred_luma_4x4_mode_vert_av8:
 
     .global ih264_intra_pred_luma_4x4_mode_horz_av8
 
-ih264_intra_pred_luma_4x4_mode_horz_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_horz_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -196,6 +196,7 @@ ih264_intra_pred_luma_4x4_mode_horz_av8:
     st1       {v4.s}[0], [x1], x3
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -256,7 +257,7 @@ ih264_intra_pred_luma_4x4_mode_horz_av8:
 
     .global ih264_intra_pred_luma_4x4_mode_dc_av8
 
-ih264_intra_pred_luma_4x4_mode_dc_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_dc_av8
 
 
 
@@ -343,6 +344,7 @@ end_func:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -399,7 +401,7 @@ end_func:
 
     .global ih264_intra_pred_luma_4x4_mode_diag_dl_av8
 
-ih264_intra_pred_luma_4x4_mode_diag_dl_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_diag_dl_av8
 
 
     push_v_regs
@@ -429,6 +431,7 @@ end_func_diag_dl:
 
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -487,7 +490,7 @@ end_func_diag_dl:
 
     .global ih264_intra_pred_luma_4x4_mode_diag_dr_av8
 
-ih264_intra_pred_luma_4x4_mode_diag_dr_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_diag_dr_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -515,6 +518,7 @@ ih264_intra_pred_luma_4x4_mode_diag_dr_av8:
 end_func_diag_dr:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -571,7 +575,7 @@ end_func_diag_dr:
 
     .global ih264_intra_pred_luma_4x4_mode_vert_r_av8
 
-ih264_intra_pred_luma_4x4_mode_vert_r_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_vert_r_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -603,6 +607,7 @@ ih264_intra_pred_luma_4x4_mode_vert_r_av8:
 end_func_vert_r:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -657,7 +662,7 @@ end_func_vert_r:
 
     .global ih264_intra_pred_luma_4x4_mode_horz_d_av8
 
-ih264_intra_pred_luma_4x4_mode_horz_d_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_horz_d_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -689,6 +694,7 @@ ih264_intra_pred_luma_4x4_mode_horz_d_av8:
 end_func_horz_d:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -745,7 +751,7 @@ end_func_horz_d:
 
     .global ih264_intra_pred_luma_4x4_mode_vert_l_av8
 
-ih264_intra_pred_luma_4x4_mode_vert_l_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_vert_l_av8
 
     push_v_regs
     stp       x19, x20, [sp, #-16]!
@@ -772,6 +778,7 @@ ih264_intra_pred_luma_4x4_mode_vert_l_av8:
 end_func_vert_l:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -828,7 +835,7 @@ end_func_vert_l:
 
     .global ih264_intra_pred_luma_4x4_mode_horz_u_av8
 
-ih264_intra_pred_luma_4x4_mode_horz_u_av8:
+ENTRY ih264_intra_pred_luma_4x4_mode_horz_u_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -866,6 +873,7 @@ ih264_intra_pred_luma_4x4_mode_horz_u_av8:
 end_func_horz_u:
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_intra_pred_luma_8x8_av8.s
+++ b/common/armv8/ih264_intra_pred_luma_8x8_av8.s
@@ -53,9 +53,8 @@
 ///**
 ///**
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 .extern ih264_gai1_intrapred_luma_8x8_horz_u
 
@@ -109,7 +108,7 @@
 
     .global ih264_intra_pred_luma_8x8_mode_vert_av8
 
-ih264_intra_pred_luma_8x8_mode_vert_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_vert_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -131,6 +130,7 @@ ih264_intra_pred_luma_8x8_mode_vert_av8:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     //ldp x19, x20,[sp],#16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -188,7 +188,7 @@ ih264_intra_pred_luma_8x8_mode_vert_av8:
 
     .global ih264_intra_pred_luma_8x8_mode_horz_av8
 
-ih264_intra_pred_luma_8x8_mode_horz_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_horz_av8
 
 
 
@@ -226,6 +226,7 @@ ih264_intra_pred_luma_8x8_mode_horz_av8:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -285,7 +286,7 @@ ih264_intra_pred_luma_8x8_mode_horz_av8:
 
     .global ih264_intra_pred_luma_8x8_mode_dc_av8
 
-ih264_intra_pred_luma_8x8_mode_dc_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_dc_av8
 
 
 
@@ -390,6 +391,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -444,7 +446,7 @@ end_func:
 
     .global ih264_intra_pred_luma_8x8_mode_diag_dl_av8
 
-ih264_intra_pred_luma_8x8_mode_diag_dl_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_diag_dl_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -495,6 +497,7 @@ end_func_diag_dl:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -548,7 +551,7 @@ end_func_diag_dl:
 
     .global ih264_intra_pred_luma_8x8_mode_diag_dr_av8
 
-ih264_intra_pred_luma_8x8_mode_diag_dr_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_diag_dr_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -596,6 +599,7 @@ end_func_diag_dr:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -649,7 +653,7 @@ end_func_diag_dr:
 
     .global ih264_intra_pred_luma_8x8_mode_vert_r_av8
 
-ih264_intra_pred_luma_8x8_mode_vert_r_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_vert_r_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -723,6 +727,7 @@ end_func_vert_r:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -775,7 +780,7 @@ end_func_vert_r:
 
     .global ih264_intra_pred_luma_8x8_mode_horz_d_av8
 
-ih264_intra_pred_luma_8x8_mode_horz_d_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_horz_d_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -853,6 +858,7 @@ end_func_horz_d:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -907,7 +913,7 @@ end_func_horz_d:
 
     .global ih264_intra_pred_luma_8x8_mode_vert_l_av8
 
-ih264_intra_pred_luma_8x8_mode_vert_l_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_vert_l_av8
 
     // STMFD sp!, {x4-x12, x14}         //Restoring registers from stack
     push_v_regs
@@ -962,6 +968,7 @@ end_func_vert_l:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -1015,7 +1022,7 @@ end_func_vert_l:
 
     .global ih264_intra_pred_luma_8x8_mode_horz_u_av8
 
-ih264_intra_pred_luma_8x8_mode_horz_u_av8:
+ENTRY ih264_intra_pred_luma_8x8_mode_horz_u_av8
 
     // STMFD sp!, {x4-x12, x14}          //store register values to stack
     push_v_regs
@@ -1071,6 +1078,7 @@ end_func_horz_u:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_iquant_itrans_recon_av8.s
+++ b/common/armv8/ih264_iquant_itrans_recon_av8.s
@@ -40,9 +40,8 @@
 // *
 // *******************************************************************************
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 ///*
 // *******************************************************************************
@@ -116,7 +115,7 @@
 //if u4_qp_div_6 is greater than 4 then shift value will be positive and do left shift, here rnd_factor is 0
 
     .global ih264_iquant_itrans_recon_4x4_av8
-ih264_iquant_itrans_recon_4x4_av8:
+ENTRY ih264_iquant_itrans_recon_4x4_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -233,6 +232,7 @@ skip_loading_luma_dc_src:
     st1       {v1.s}[1], [x2]           //iv row store the value
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -303,7 +303,7 @@ skip_loading_luma_dc_src:
 //sp#8 => *pi2_dc_src
 
     .global ih264_iquant_itrans_recon_chroma_4x4_av8
-ih264_iquant_itrans_recon_chroma_4x4_av8:
+ENTRY ih264_iquant_itrans_recon_chroma_4x4_av8
 
 //VLD4.S16 is used because the pointer is incremented by SUB_BLK_WIDTH_4x4
 //If the macro value changes need to change the instruction according to it.
@@ -455,6 +455,7 @@ ih264_iquant_itrans_recon_chroma_4x4_av8:
     st1       {v13.8b}, [x0]
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 ///*
@@ -526,7 +527,7 @@ ih264_iquant_itrans_recon_chroma_4x4_av8:
 //NOT USED =>  pi2_dc_ld_addr
 
     .global ih264_iquant_itrans_recon_8x8_av8
-ih264_iquant_itrans_recon_8x8_av8:
+ENTRY ih264_iquant_itrans_recon_8x8_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -777,6 +778,7 @@ trans_1x8_1d:
     st1       {v7.8b}, [x2]
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_iquant_itrans_recon_dc_av8.s
+++ b/common/armv8/ih264_iquant_itrans_recon_dc_av8.s
@@ -114,10 +114,9 @@
 //   =>  pi2_dc_ld_addr
 
 .text
-.p2align 2
 
     .global ih264_iquant_itrans_recon_4x4_dc_av8
-ih264_iquant_itrans_recon_4x4_dc_av8:
+ENTRY ih264_iquant_itrans_recon_4x4_dc_av8
 
     sxtw      x3, w3
     sxtw      x4, w4
@@ -166,6 +165,7 @@ donot_use_pi2_src_luma_dc:
     st1       {v2.s}[0], [x2], x4
     st1       {v2.s}[1], [x2]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 // /*
@@ -223,7 +223,7 @@ donot_use_pi2_src_luma_dc:
 
 
     .global ih264_iquant_itrans_recon_chroma_4x4_dc_av8
-ih264_iquant_itrans_recon_chroma_4x4_dc_av8:
+ENTRY ih264_iquant_itrans_recon_chroma_4x4_dc_av8
 
     sxtw      x3, w3
     sxtw      x4, w4
@@ -270,6 +270,7 @@ ih264_iquant_itrans_recon_chroma_4x4_dc_av8:
     st1       {v12.d}[0], [x0], x4
     st1       {v12.d}[1], [x0]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 ///*
@@ -341,7 +342,7 @@ ih264_iquant_itrans_recon_chroma_4x4_dc_av8:
 //NOT USED =>  pi2_dc_ld_addr
 
     .global ih264_iquant_itrans_recon_8x8_dc_av8
-ih264_iquant_itrans_recon_8x8_dc_av8:
+ENTRY ih264_iquant_itrans_recon_8x8_dc_av8
 
     push_v_regs
     sxtw      x3, w3
@@ -398,6 +399,7 @@ ih264_iquant_itrans_recon_8x8_dc_av8:
     st1       {v12.8b}, [x2]
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_mem_fns_neon_av8.s
+++ b/common/armv8/ih264_mem_fns_neon_av8.s
@@ -41,9 +41,8 @@
 // *******************************************************************************
 //*/
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 ///**
 //*******************************************************************************
 //*
@@ -82,7 +81,7 @@
 
     .global ih264_memcpy_mul_8_av8
 
-ih264_memcpy_mul_8_av8:
+ENTRY ih264_memcpy_mul_8_av8
 
 loop_neon_memcpy_mul_8:
     // Memcpy 8 bytes
@@ -91,6 +90,7 @@ loop_neon_memcpy_mul_8:
 
     subs      w2, w2, #8
     bne       loop_neon_memcpy_mul_8
+    EXIT_FUNC
     ret
 
 
@@ -109,7 +109,7 @@ loop_neon_memcpy_mul_8:
 
     .global ih264_memcpy_av8
 
-ih264_memcpy_av8:
+ENTRY ih264_memcpy_av8
     subs      w2, w2, #8
     blt       arm_memcpy
 loop_neon_memcpy:
@@ -130,8 +130,10 @@ loop_arm_memcpy:
     strb      w3, [x0], #1
     subs      w2, w2, #1
     bne       loop_arm_memcpy
+    EXIT_FUNC
     ret
 end_func1:
+    EXIT_FUNC
     ret
 
 
@@ -146,7 +148,7 @@ end_func1:
 
     .global ih264_memset_mul_8_av8
 
-ih264_memset_mul_8_av8:
+ENTRY ih264_memset_mul_8_av8
 
 // Assumptions: numbytes is either 8, 16 or 32
     dup       v0.8b, w1
@@ -157,6 +159,7 @@ loop_memset_mul_8:
     subs      w2, w2, #8
     bne       loop_memset_mul_8
 
+    EXIT_FUNC
     ret
 
 
@@ -172,7 +175,7 @@ loop_memset_mul_8:
 
     .global ih264_memset_av8
 
-ih264_memset_av8:
+ENTRY ih264_memset_av8
     subs      w2, w2, #8
     blt       arm_memset
     dup       v0.8b, w1
@@ -192,8 +195,10 @@ loop_arm_memset:
     strb      w1, [x0], #1
     subs      w2, w2, #1
     bne       loop_arm_memset
+    EXIT_FUNC
     ret
 end_func2:
+    EXIT_FUNC
     ret
 
 
@@ -211,7 +216,7 @@ end_func2:
 
     .global ih264_memset_16bit_mul_8_av8
 
-ih264_memset_16bit_mul_8_av8:
+ENTRY ih264_memset_16bit_mul_8_av8
 
 // Assumptions: num_words is either 8, 16 or 32
 
@@ -224,6 +229,7 @@ loop_memset_16bit_mul_8:
     subs      w2, w2, #8
     bne       loop_memset_16bit_mul_8
 
+    EXIT_FUNC
     ret
 
 
@@ -240,7 +246,7 @@ loop_memset_16bit_mul_8:
 
     .global ih264_memset_16bit_av8
 
-ih264_memset_16bit_av8:
+ENTRY ih264_memset_16bit_av8
     subs      w2, w2, #8
     blt       arm_memset_16bit
     dup       v0.4h, w1
@@ -261,9 +267,11 @@ loop_arm_memset_16bit:
     strh      w1, [x0], #2
     subs      w2, w2, #1
     bne       loop_arm_memset_16bit
+    EXIT_FUNC
     ret
 
 end_func3:
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_neon_macros.s
+++ b/common/armv8/ih264_neon_macros.s
@@ -39,3 +39,52 @@
     eor       \reg1, \reg1, \reg2
 .endm
 
+// --- Internal Security Dispatchers ---
+// These expand to real instructions only if the compiler flags are present.
+
+.macro BTI_ENABLE
+#if defined(__ARM_FEATURE_BTI_DEFAULT)
+    bti c
+#endif
+.endm
+
+.macro PAC_ENTRY
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+    paciasp
+#endif
+.endm
+
+.macro PAC_EXIT
+#if defined(__ARM_FEATURE_PAC_DEFAULT)
+    autiasp
+#endif
+.endm
+
+// --- Main ENTRY and EXIT_FUNC Macros ---
+
+.macro ENTRY name
+    .p2align 2
+\name:
+    BTI_ENABLE
+    PAC_ENTRY
+.endm
+
+.macro EXIT_FUNC
+    PAC_EXIT
+.endm
+
+// --- GNU Property Note ---
+// Signals BTI and PAC support to the Android linker.
+#if defined(__linux__) && defined(__aarch64__)
+    .pushsection .note.gnu.property, "a"  // Switch to Note section
+    .p2align 3
+    .word 4           // Name size
+    .word 16          // Data size
+    .word 5           // NT_GNU_PROPERTY_TYPE_0
+    .asciz "GNU"      // Owner
+    .word 0xc0000000  // GNU_PROPERTY_AARCH64_FEATURE_1_AND
+    .word 4           // Data size
+    .word 3           // Value: BTI (Bit 0) | PAC (Bit 1)
+    .word 0           // Padding
+    .popsection                           // Switch back to previous section
+#endif

--- a/common/armv8/ih264_padding_neon_av8.s
+++ b/common/armv8/ih264_padding_neon_av8.s
@@ -41,9 +41,9 @@
 // *******************************************************************************
 //*/
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
+
 ///**
 //*******************************************************************************
 //*
@@ -82,7 +82,7 @@
 
     .global ih264_pad_top_av8
 
-ih264_pad_top_av8:
+ENTRY ih264_pad_top_av8
 
     // STMFD sp!, {x4-x11,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -110,6 +110,7 @@ loop_neon_pad_top:
     // LDMFD sp!,{x4-x11,pc}                //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -168,7 +169,7 @@ loop_neon_pad_top:
 
     .global ih264_pad_left_luma_av8
 
-ih264_pad_left_luma_av8:
+ENTRY ih264_pad_left_luma_av8
 
     // STMFD sp!, {x4-x11,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -268,6 +269,7 @@ end_func:
     // LDMFD sp!,{x4-x11,pc}                //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -327,7 +329,7 @@ end_func:
 
     .global ih264_pad_left_chroma_av8
 
-ih264_pad_left_chroma_av8:
+ENTRY ih264_pad_left_chroma_av8
 
     // STMFD sp!, {x4-x11, x14}                //stack stores the values of the arguments
     push_v_regs
@@ -415,6 +417,7 @@ end_func_l_c:
     // LDMFD sp!,{x4-x11,pc}                //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -484,7 +487,7 @@ end_func_l_c:
 
     .global ih264_pad_right_luma_av8
 
-ih264_pad_right_luma_av8:
+ENTRY ih264_pad_right_luma_av8
 
     // STMFD sp!, {x4-x11, x14}                //stack stores the values of the arguments
     push_v_regs
@@ -584,6 +587,7 @@ end_func_r:
     // LDMFD sp!,{x4-x11,pc}                //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -642,7 +646,7 @@ end_func_r:
 
     .global ih264_pad_right_chroma_av8
 
-ih264_pad_right_chroma_av8:
+ENTRY ih264_pad_right_chroma_av8
 
     // STMFD sp!, {x4-x11, x14}                //stack stores the values of the arguments
     push_v_regs
@@ -727,6 +731,7 @@ end_func_r_c:
     // LDMFD sp!,{x4-x11,pc}                //Reload the registers from SP
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_resi_trans_quant_av8.s
+++ b/common/armv8/ih264_resi_trans_quant_av8.s
@@ -39,7 +39,6 @@
 //*******************************************************************************
 .include "ih264_neon_macros.s"
 .text
-.p2align 2
 //*****************************************************************************
 //*
 //* function name     : ih264_resi_trans_quant_4x4
@@ -63,7 +62,7 @@
 //*****************************************************************************
 
     .global ih264_resi_trans_quant_4x4_av8
-ih264_resi_trans_quant_4x4_av8:
+ENTRY ih264_resi_trans_quant_4x4_av8
 
     push_v_regs
     //x0     :pointer to src buffer
@@ -228,6 +227,7 @@ ih264_resi_trans_quant_4x4_av8:
     st1       {v26.b}[0], [x9]          //write nnz
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -254,7 +254,7 @@ ih264_resi_trans_quant_4x4_av8:
 //*****************************************************************************
 
     .global ih264_resi_trans_quant_chroma_4x4_av8
-ih264_resi_trans_quant_chroma_4x4_av8:
+ENTRY ih264_resi_trans_quant_chroma_4x4_av8
 
     push_v_regs
     //x0     :pointer to src buffer
@@ -430,6 +430,7 @@ ih264_resi_trans_quant_chroma_4x4_av8:
     st1       {v26.b}[0], [x9]          //write nnz
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -577,6 +578,7 @@ ih264_hadamard_quant_4x4_av8:
     st1       {v20.b}[0], [x6]
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -615,7 +617,7 @@ ih264_hadamard_quant_4x4_av8:
 //                             )
 
     .global ih264_hadamard_quant_2x2_uv_av8
-ih264_hadamard_quant_2x2_uv_av8:
+ENTRY ih264_hadamard_quant_2x2_uv_av8
 
     push_v_regs
 
@@ -682,6 +684,7 @@ ih264_hadamard_quant_2x2_uv_av8:
     st1       {v20.h}[0], [x6]          //store nnz
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_weighted_bi_pred_av8.s
+++ b/common/armv8/ih264_weighted_bi_pred_av8.s
@@ -126,15 +126,14 @@
 //    [sp+24] => ht        (w11)
 //    [sp+32] => wd        (w12)
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_weighted_bi_pred_luma_av8
 
-ih264_weighted_bi_pred_luma_av8:
+ENTRY ih264_weighted_bi_pred_luma_av8
 
     // STMFD sp!, {x4-x12,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -317,6 +316,7 @@ end_loops:
     // LDMFD sp!,{x4-x12,x15}                //Reload the registers from sp
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -415,7 +415,7 @@ end_loops:
 
     .global ih264_weighted_bi_pred_chroma_av8
 
-ih264_weighted_bi_pred_chroma_av8:
+ENTRY ih264_weighted_bi_pred_chroma_av8
 
     // STMFD sp!, {x4-x12,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -567,6 +567,7 @@ end_loops_uv:
     // LDMFD sp!,{x4-x12,x15}                //Reload the registers from sp
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/common/armv8/ih264_weighted_pred_av8.s
+++ b/common/armv8/ih264_weighted_pred_av8.s
@@ -106,15 +106,14 @@
 //    w7      => ht
 //    [sp]    => wd     (w8)
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 
 
     .global ih264_weighted_pred_luma_av8
 
-ih264_weighted_pred_luma_av8:
+ENTRY ih264_weighted_pred_luma_av8
 
     // STMFD sp!, {x4-x9,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -265,6 +264,7 @@ end_loops:
     // LDMFD sp!,{x4-x9,x15}                      //Reload the registers from sp
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -342,7 +342,7 @@ end_loops:
 
     .global ih264_weighted_pred_chroma_av8
 
-ih264_weighted_pred_chroma_av8:
+ENTRY ih264_weighted_pred_chroma_av8
 
     // STMFD sp!, {x4-x9,x14}                //stack stores the values of the arguments
     push_v_regs
@@ -466,6 +466,7 @@ end_loops_uv:
     // LDMFD sp!,{x4-x9,x15}                      //Reload the registers from sp
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/encoder/armv8/ih264e_evaluate_intra16x16_modes_av8.s
+++ b/encoder/armv8/ih264e_evaluate_intra16x16_modes_av8.s
@@ -71,13 +71,12 @@
 //                                      WORD32 *pu4_sadmin,
 //                                       UWORD32 u4_valid_intra_modes)
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 .global ih264e_evaluate_intra16x16_modes_av8
 
-ih264e_evaluate_intra16x16_modes_av8:
+ENTRY ih264e_evaluate_intra16x16_modes_av8
 
 //x0 = pu1_src,
 //x1 = pu1_ngbr_pels_i16,
@@ -587,6 +586,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/encoder/armv8/ih264e_evaluate_intra_chroma_modes_av8.s
+++ b/encoder/armv8/ih264e_evaluate_intra_chroma_modes_av8.s
@@ -71,13 +71,12 @@
 //                                      WORD32 *pu4_sadmin,
 //                                       UWORD32 u4_valid_intra_modes)
 //
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 .global ih264e_evaluate_intra_chroma_modes_av8
 
-ih264e_evaluate_intra_chroma_modes_av8:
+ENTRY ih264e_evaluate_intra_chroma_modes_av8
 
 //x0 = pu1_src,
 //x1 = pu1_ngbr_pels_i16,
@@ -463,6 +462,7 @@ end_func:
     // LDMFD sp!,{x4-x12,PC}         //Restoring registers from stack
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/encoder/armv8/ih264e_half_pel_av8.s
+++ b/encoder/armv8/ih264e_half_pel_av8.s
@@ -40,9 +40,8 @@
 // */
 
 
-.text
-.p2align 2
 .include "ih264_neon_macros.s"
+.text
 
 ///*******************************************************************************
 //*
@@ -83,7 +82,7 @@
 
 
         .global ih264e_sixtapfilter_horz_av8
-ih264e_sixtapfilter_horz_av8:
+ENTRY ih264e_sixtapfilter_horz_av8
     // STMFD sp!,{x14}
     push_v_regs
     sxtw      x2, w2
@@ -191,6 +190,7 @@ filter_horz_loop:
     // LDMFD sp!,{pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -262,7 +262,7 @@ filter_horz_loop:
 
         .global ih264e_sixtap_filter_2dvh_vert_av8
 
-ih264e_sixtap_filter_2dvh_vert_av8:
+ENTRY ih264e_sixtap_filter_2dvh_vert_av8
     // STMFD sp!,{x10,x11,x12,x14}
     push_v_regs
     sxtw      x3, w3
@@ -1000,6 +1000,7 @@ filter_2dvh_loop:
     // LDMFD sp!,{x10,x11,x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 filter_2dvh_skip_row:
@@ -1014,6 +1015,7 @@ filter_2dvh_skip_row:
     // LDMFD sp!,{x10,x11,x12,pc}
     ldp       x19, x20, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret
 
 

--- a/encoder/armv8/ime_distortion_metrics_av8.s
+++ b/encoder/armv8/ime_distortion_metrics_av8.s
@@ -76,24 +76,11 @@
 //*
 //******************************************************************************
 //*/
+.include "ih264_neon_macros.s"
 .text
-.p2align 2
-
-.macro push_v_regs
-    stp       d8, d9, [sp, #-16]!
-    stp       d10, d11, [sp, #-16]!
-    stp       d12, d13, [sp, #-16]!
-    stp       d14, d15, [sp, #-16]!
-.endm
-.macro pop_v_regs
-    ldp       d14, d15, [sp], #16
-    ldp       d12, d13, [sp], #16
-    ldp       d10, d11, [sp], #16
-    ldp       d8, d9, [sp], #16
-.endm
 
     .global ime_compute_sad_16x16_fast_av8
-ime_compute_sad_16x16_fast_av8:
+ENTRY ime_compute_sad_16x16_fast_av8
     push_v_regs
     sxtw      x2, w2
     sxtw      x3, w3
@@ -138,6 +125,7 @@ core_loop_ime_compute_sad_16x16_fast_av8:
 
     st1       {v30.s}[0], [x5]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -176,7 +164,7 @@ core_loop_ime_compute_sad_16x16_fast_av8:
 //*/
 //
     .global ime_compute_sad_16x8_av8
-ime_compute_sad_16x8_av8:
+ENTRY ime_compute_sad_16x8_av8
 
     //chheck what stride incremtn to use
     //earlier code did not have this lsl
@@ -220,6 +208,7 @@ core_loop_ime_compute_sad_16x8_av8:
 
     st1       {v30.s}[0], [x5]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 ///**
@@ -256,7 +245,7 @@ core_loop_ime_compute_sad_16x8_av8:
 //*/
 
     .global ime_compute_sad_16x16_ea8_av8
-ime_compute_sad_16x16_ea8_av8:
+ENTRY ime_compute_sad_16x16_ea8_av8
 
     push_v_regs
     sxtw      x2, w2
@@ -366,6 +355,7 @@ ime_compute_sad_16x16_ea8_av8:
 end_func_16x16:
     st1       {v31.s}[0], [x5]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -382,7 +372,7 @@ end_func_16x16:
 //*/
 
     .global ime_calculate_sad2_prog_av8
-ime_calculate_sad2_prog_av8:
+ENTRY ime_calculate_sad2_prog_av8
 
     // x0    = ref1     <UWORD8 *>
     // x1    = ref2     <UWORD8 *>
@@ -447,6 +437,7 @@ core_loop_ime_calculate_sad2_prog_av8:
 
     st1       {v30.2s}, [x5]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 ///*
@@ -462,7 +453,7 @@ core_loop_ime_calculate_sad2_prog_av8:
 //*/
 
     .global ime_calculate_sad3_prog_av8
-ime_calculate_sad3_prog_av8:
+ENTRY ime_calculate_sad3_prog_av8
 
     // x0    = ref1     <UWORD8 *>
     // x1    = ref2     <UWORD8 *>
@@ -517,6 +508,7 @@ core_loop_ime_calculate_sad3_prog_av8:
 
     st1       {v30.2s}, [x6]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -550,7 +542,7 @@ core_loop_ime_calculate_sad3_prog_av8:
 .p2align 2
 
     .global ime_sub_pel_compute_sad_16x16_av8
-ime_sub_pel_compute_sad_16x16_av8:
+ENTRY ime_sub_pel_compute_sad_16x16_av8
     push_v_regs
     sxtw      x4, w4
     sxtw      x5, w5
@@ -619,6 +611,7 @@ core_loop_ime_sub_pel_compute_sad_16x16_av8:
 
 
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -655,7 +648,7 @@ core_loop_ime_sub_pel_compute_sad_16x16_av8:
 //******************************************************************************
 //*/
     .global ime_compute_sad_16x16_av8
-ime_compute_sad_16x16_av8:
+ENTRY ime_compute_sad_16x16_av8
     push_v_regs
     sxtw      x2, w2
     sxtw      x3, w3
@@ -696,6 +689,7 @@ core_loop_ime_compute_sad_16x16_av8:
 
     st1       {v30.s}[0], [x5]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -712,7 +706,7 @@ core_loop_ime_compute_sad_16x16_av8:
 //*/
 
     .global ime_calculate_sad4_prog_av8
-ime_calculate_sad4_prog_av8:
+ENTRY ime_calculate_sad4_prog_av8
     push_v_regs
     sxtw      x2, w2
     sxtw      x3, w3
@@ -756,6 +750,7 @@ core_loop_ime_calculate_sad4_prog_av8:
     addp      v28.4s, v28.4s, v30.4s
     st1       {v28.4s}, [x4]
     pop_v_regs
+    EXIT_FUNC
     ret
 
 
@@ -788,7 +783,7 @@ core_loop_ime_calculate_sad4_prog_av8:
 //*
 //*****************************************************************************
     .global ime_compute_satqd_16x16_lumainter_av8
-ime_compute_satqd_16x16_lumainter_av8:
+ENTRY ime_compute_satqd_16x16_lumainter_av8
     //x0 :pointer to src buffer
     //x1 :pointer to est buffer
     //w2 :Source stride
@@ -990,4 +985,5 @@ satdq_end_func:
     ldp       d10, d11, [sp], #16
     ldp       d8, d9, [sp], #16
     pop_v_regs
+    EXIT_FUNC
     ret

--- a/examples/Android.bp
+++ b/examples/Android.bp
@@ -9,9 +9,6 @@ package {
 
 cc_defaults {
     name: "avcdec_defaults",
-    defaults: [
-        "no_bti",
-    ],
     gtest: false,
     host_supported: true,
     cflags: [
@@ -32,9 +29,6 @@ cc_defaults {
 
 cc_defaults {
     name: "avcenc_defaults",
-    defaults: [
-        "no_bti",
-    ],
     gtest: false,
     host_supported: true,
     cflags: [

--- a/fuzzer/Android.bp
+++ b/fuzzer/Android.bp
@@ -9,9 +9,6 @@ package {
 
 cc_defaults {
     name: "libavc_fuzzer_defaults",
-    defaults: [
-        "no_bti",
-    ],
     host_supported: true,
     static_libs: ["liblog"],
     target: {

--- a/tests/Android.bp
+++ b/tests/Android.bp
@@ -25,9 +25,6 @@ package {
 
 cc_test {
     name: "AvcEncTest",
-    defaults: [
-        "no_bti",
-    ],
     gtest: true,
     test_suites: ["device-tests"],
 


### PR DESCRIPTION
Bug: 485868924
Test: readelf -nW libavcdec.a
Test: readelf -nW libavcenc.a
Test: atest MctsMediaV2TestCases
      atest MctsMediaDecoderTestCases
      atest MctsMediaEncoderTestCases
      atest MctsMediaCodecTestCases
Test: avc_dec_fuzzer
      avc_enc_fuzzer

Change-Id: I293442de891c72a6977012131f50b5a52c1bcd3a